### PR TITLE
Logout Redirect and Database Password Logins

### DIFF
--- a/src/components/Auth.js
+++ b/src/components/Auth.js
@@ -36,7 +36,7 @@ class Auth {
   handleAuthentication = () => {
     return new Promise((resolve, reject) => {
       this.auth0.parseHash((err, authResult) => { // parse the callback's query parameter access token
-        
+        console.log('manage login', authResult);
 
         if (err) return reject(err);
         if (!authResult || !authResult.idToken) {

--- a/src/components/Auth.js
+++ b/src/components/Auth.js
@@ -65,6 +65,7 @@ class Auth {
     this.idToken = null;
     this.profile = null;
     this.expiresAt = null;
+    this.accessToken = null;
 
     // clear local storage
     localStorage.removeItem('name');
@@ -75,6 +76,7 @@ class Auth {
     localStorage.removeItem('isLoggedIn');
     localStorage.removeItem('accountType');
     localStorage.removeItem('userInfo');
+
   }
 }
 

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -133,12 +133,18 @@ class Navigation extends React.Component {
     }
 
     handleLogin = () => {
-        if(!this.state.accountType){
-            window.alert('You must select an account type!')
-        } else {
-            localStorage.setItem('accountType', this.state.accountType);
-            lock.show();
-        }
+        /**
+         * Lock module will not work with database logins unless we pay for auth0 custom domain.
+         */
+
+        // if(!this.state.accountType){
+        //     window.alert('You must select an account type!')
+        // } else {
+        //     localStorage.setItem('accountType', this.state.accountType);
+        //     lock.show();
+        // }
+
+        auth.login();
     }
 
     handleLogout = event => {

--- a/src/components/Navigation.js
+++ b/src/components/Navigation.js
@@ -143,8 +143,10 @@ class Navigation extends React.Component {
 
     handleLogout = event => {
         event.preventDefault();
+        
         auth.logout();
-        this.props.history.replace('/');
+        
+        window.location = `https://${process.env.REACT_APP_AUTH0_DOMAIN}/v2/logout`;
     }
 
     render(){


### PR DESCRIPTION
This reverts back to the redirect auth0 login, as the lock module will not be able to complete username/password logins due to a CORS issue that can only be resolved by paying auth0 for a custom domain service (how convenient for them...).

Also, the logout method now hits the proper auth0 logout endpoint and will redirect the user back to `wellbroomed.com` after completely logging them out of auth0 and clearing the browser of user information. 

I've tried passing a localhost `returnTo` value to the logout method, but it hits an error and does not process. Redirecting to the root production domain is fine, as this will be the desired end result anyway, so I'm not going to split hairs about it.