### PR TITLE
Account Settings Page (front-end)

### DIFF
--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -3,6 +3,8 @@ import axios from 'axios';
 export const ERROR = 'ERROR';
 export const CHECKING_USER = 'CHECKING_USER';
 export const USER_CHECKED = 'USER_CHECKED';
+export const UPDATING_USER = 'UPDATING_USER';
+export const USER_UPDATED = 'USER_UPDATED';
 
 const backendUrl = process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`
 
@@ -36,6 +38,31 @@ export const checkIfUserExists = (role) => {
         }).catch(err => {
             console.log(err);
             dispatch({type: ERROR})
+        })
+    }
+}
+
+export const updateUserProfile = (user_id, changes) => {
+    
+    let token = localStorage.getItem('jwt');
+	let userInfo = localStorage.getItem('userInfo');
+
+	let options = {
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'user-info': userInfo
+		}
+	};
+    const endpoint = axios.put(`${backendUrl}/api/users/${user_id}`, changes, options);
+
+    return dispatch => {
+        dispatch({type: UPDATING_USER});
+
+        endpoint.then(res => {
+            dispatch({type: USER_UPDATED, payload: res.data});
+        }).catch(err => {
+            console.log(err);
+            dispatch({type: ERROR});
         })
     }
 }

--- a/src/components/Account.js
+++ b/src/components/Account.js
@@ -5,17 +5,182 @@ import {connect} from 'react-redux';
 // Router
 import {withRouter} from 'react-router-dom';
 
+// FlexBox
+
+// Card
+import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+import Button from '@material-ui/core/Button';
+import IconButton from '@material-ui/core/IconButton';
+import Typography from '@material-ui/core/Typography';
+import TextField from '@material-ui/core/TextField';
+import { withStyles } from '@material-ui/core';
+
+// Icons 
+import EditTwoTone from '@material-ui/icons/EditTwoTone';
+import Icon from '@material-ui/core/Icon';
+
+// Styled Components
+import styled from 'styled-components';
+
+const FlexRowNoWrap = styled.div`
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    `;
+
+const FlexColNoWrap = styled.div`
+    display: flex;
+    flex-flow: column nowrap;
+    justify-content: center;
+    `;
+
+const styles = {
+    card: {
+        maxWidth: 400,
+        marginTop: 40,
+    },
+    media: {
+        height: 200,
+    }
+}
 
 class Account extends React.Component {
+
+    // set default input values
+    componentDidUpdate(prevProps){
+        if(this.props.currentUser !== prevProps.currentUser){
+            this.setState({
+                username: this.props.currentUser.user_name
+            })
+        }
+    }
+
     constructor(props){
         super(props);
         this.state = {
+            passwordOpen: false,
+            password1: '',
+            password2: '',
+            username: '',
+            usernameOpen: false,
+            emailOpen: false,
+            email: '',
         };
     }
 
+    handleInput = event => {
+        event.preventDefault();
+        this.setState({
+            [event.target.name]: event.target.value,
+        })
+
+    }
+
+    toggleInput = event => {
+        event.preventDefault();
+        let name;
+        /**
+         * So this is a tricky bit due to material UI svg icons.
+         * If you click on the svg itself, the usual onClick event 'name' passage will not work.
+         * So, you have to traverse two levels up the DOM to gather the proper name
+         * in order for the dynamic state assignment to fire properly.
+         */
+        if(event.target.tagName === 'path'){
+            name = event.target.parentNode.parentNode.getAttribute('name');
+            this.setState({
+                [name]: !this.state[name]
+            });
+        } else {
+            name = event.target.getAttribute('name');
+            this.setState({
+                [name]: !this.state[name]
+            });
+        }
+    }
+
+    handleSubmit = event => {
+        event.preventDefault();
+        console.log('submit');
+    }
+
     render(){
+        const {classes} = this.props;
         return (
             <div>
+                <Typography variant = 'h2'>Account</Typography>
+                {this.props.currentUser ? (
+                     <Card className = {classes.card}>
+                     <CardActionArea>
+                         <CardMedia className = {classes.media} 
+                         image = {this.props.currentUser.img_url} 
+                         title = 'Profile Picture'/>
+                     </CardActionArea>
+                     <CardContent>
+                        <Typography variant = 'overline'>Username</Typography>
+                        {!this.state.usernameOpen ? (
+                            <FlexRowNoWrap>
+                            <Typography variant = 'h6'>{this.props.currentUser.user_name}</Typography>
+                            <IconButton onClick = {this.toggleInput} name = 'usernameOpen'><EditTwoTone name = 'usernameOpen'/></IconButton>
+                            </FlexRowNoWrap>
+                        ) : null}
+
+                        
+                        {this.state.usernameOpen ? (
+                            <form onSubmit = {this.handleSubmit}>
+                            <FlexColNoWrap>
+                            <TextField variant = 'outlined' label = 'New Username' name = 'username' value = {this.state.username} onChange = {this.handleInput}></TextField>
+                        
+                            <FlexRowNoWrap>
+                            <Button onClick = {this.toggleInput} name = 'usernameOpen'><div name = 'usernameOpen' onClick = {this.toggleInput}>Cancel</div></Button>
+                            <Button type = 'submit'>Submit</Button>
+                            </FlexRowNoWrap>
+                            </FlexColNoWrap>
+                        </form>
+                        ) : null}
+                        
+
+                        <Typography variant = 'overline'>Email</Typography>
+                        <Typography variant = 'h6'>{this.props.currentUser.email}</Typography>
+
+                        <Typography variant = 'overline'>Account Type</Typography>
+                        <Typography variant = 'h6'>{this.props.currentUser.role}</Typography>
+
+                        <Typography variant = 'overline'>Password</Typography>
+
+                        {!this.state.passwordOpen ? (
+                            <Button variant = 'contained' color = 'secondary' onClick = {this.toggleInput} name = 'passwordOpen'>
+                                <div style = {{width: '100%'}} className = 'password-btn' name = 'passwordOpen' onClick = {this.toggleInput}>
+                                Change Password
+                                </div>
+                            </Button>
+                        ) : null}
+                        
+                        {this.state.passwordOpen ? (
+                            <form onSubmit = {this.handleSubmit}>
+                            <FlexColNoWrap>
+                                <TextField variant = 'outlined' label = 'New Password' type = 'password' name = 'password1' value = {this.state.password1}></TextField>
+                                <TextField variant = 'outlined' label = 'New Password (Again)' type = 'password' name = 'password2' value = {this.state.password2}></TextField>    
+                                
+                                <FlexRowNoWrap>
+                                    <Button><div name = 'passwordOpen' onClick = {this.toggleInput}>Cancel</div></Button>
+                                    <Button type = 'submit'>Submit</Button>
+                                </FlexRowNoWrap>
+                            </FlexColNoWrap>
+                            </form>
+                        ) : null}
+                        
+                     </CardContent>
+ 
+ 
+                 </Card>
+                ) : null}
+               
+
+
             </div>
         )
     }
@@ -25,12 +190,11 @@ class Account extends React.Component {
 const mapStateToProps = state => {
     return {
         // state items
+        currentUser: state.authReducer.currentUser
     }
 }
 
 export default withRouter(connect(mapStateToProps, {
     // actions
     
-})(Account))
-
-
+})(withStyles(styles)(Account)));

--- a/src/components/Account.js
+++ b/src/components/Account.js
@@ -5,6 +5,8 @@ import {connect} from 'react-redux';
 // Router
 import {withRouter} from 'react-router-dom';
 
+import {updateUserProfile} from '../actions/index';
+
 // FlexBox
 
 // Card
@@ -50,15 +52,18 @@ const styles = {
 
 class Account extends React.Component {
 
-    // set default input values
     componentDidUpdate(prevProps){
-        if(this.props.currentUser !== prevProps.currentUser){
+        if(this.props.userChecked !== prevProps.userChecked){
             this.setState({
-                username: this.props.currentUser.user_name
+                username: this.props.currentUser.user_name,
+                email: this.props.currentUser.email,
+                passwordOpen: false,
+                usernameOpen: false,
+                emailOpen: false,
             })
         }
     }
-
+    // set default input values
     constructor(props){
         super(props);
         this.state = {
@@ -104,7 +109,26 @@ class Account extends React.Component {
 
     handleSubmit = event => {
         event.preventDefault();
-        console.log('submit');
+        let changes = {};
+        let user_id = this.props.currentUser.user_id;
+        if(event.target.name === 'username'){
+            changes.user_name = this.state.username;
+            this.props.updateUserProfile(user_id, changes);
+        } else if(event.target.name === 'password'){
+            if(this.state.password1 === this.state.password2){
+                changes.password = this.state.password2;
+                this.props.updateUserProfile(user_id, changes);
+            } else {
+                window.alert('Passwords must match! Please re-enter your passwords.');
+            }
+        } else if (event.target.name = 'email'){
+            /**
+             * TODO: MAKE SURE THE EMAIL IS A VALID ADDRESS
+             */
+
+            changes.email = this.state.email;
+            this.props.updateUserProfile(user_id, changes);
+        }
     }
 
     render(){
@@ -112,7 +136,7 @@ class Account extends React.Component {
         return (
             <div>
                 <Typography variant = 'h2'>Account</Typography>
-                {this.props.currentUser ? (
+                {(this.props.userChecked && this.props.currentUser) ? (
                      <Card className = {classes.card}>
                      <CardActionArea>
                          <CardMedia className = {classes.media} 
@@ -130,7 +154,7 @@ class Account extends React.Component {
 
                         
                         {this.state.usernameOpen ? (
-                            <form onSubmit = {this.handleSubmit}>
+                            <form name = 'username' onSubmit = {this.handleSubmit}>
                             <FlexColNoWrap>
                             <TextField variant = 'outlined' label = 'New Username' name = 'username' value = {this.state.username} onChange = {this.handleInput}></TextField>
                         
@@ -144,7 +168,26 @@ class Account extends React.Component {
                         
 
                         <Typography variant = 'overline'>Email</Typography>
-                        <Typography variant = 'h6'>{this.props.currentUser.email}</Typography>
+                        {!this.state.emailOpen ? (
+                            <FlexRowNoWrap>
+                            <Typography variant = 'h6'>{this.props.currentUser.email}</Typography>
+                            <IconButton onClick = {this.toggleInput} name = 'emailOpen'><EditTwoTone name = 'emailOpen'/></IconButton>
+                            </FlexRowNoWrap>
+                        ) : null}
+
+                        
+                        {this.state.emailOpen ? (
+                            <form name = 'email' onSubmit = {this.handleSubmit}>
+                            <FlexColNoWrap>
+                            <TextField variant = 'outlined' label = 'New Email' name = 'email' value = {this.state.email} onChange = {this.handleInput}></TextField>
+                        
+                            <FlexRowNoWrap>
+                            <Button onClick = {this.toggleInput} name = 'emailOpen'><div name = 'emailOpen' onClick = {this.toggleInput}>Cancel</div></Button>
+                            <Button type = 'submit'>Submit</Button>
+                            </FlexRowNoWrap>
+                            </FlexColNoWrap>
+                        </form>
+                        ) : null}
 
                         <Typography variant = 'overline'>Account Type</Typography>
                         <Typography variant = 'h6'>{this.props.currentUser.role}</Typography>
@@ -160,10 +203,10 @@ class Account extends React.Component {
                         ) : null}
                         
                         {this.state.passwordOpen ? (
-                            <form onSubmit = {this.handleSubmit}>
+                            <form name = 'password' onSubmit = {this.handleSubmit}>
                             <FlexColNoWrap>
-                                <TextField variant = 'outlined' label = 'New Password' type = 'password' name = 'password1' value = {this.state.password1}></TextField>
-                                <TextField variant = 'outlined' label = 'New Password (Again)' type = 'password' name = 'password2' value = {this.state.password2}></TextField>    
+                                <TextField variant = 'outlined' label = 'New Password' type = 'password' name = 'password1' value = {this.state.password1} onChange = {this.handleInput}></TextField>
+                                <TextField variant = 'outlined' label = 'New Password (Again)' type = 'password' name = 'password2' value = {this.state.password2} onChange = {this.handleInput}></TextField>    
                                 
                                 <FlexRowNoWrap>
                                     <Button><div name = 'passwordOpen' onClick = {this.toggleInput}>Cancel</div></Button>
@@ -177,7 +220,7 @@ class Account extends React.Component {
  
  
                  </Card>
-                ) : null}
+                ) : <h1>Lodaing...</h1>}
                
 
 
@@ -190,11 +233,13 @@ class Account extends React.Component {
 const mapStateToProps = state => {
     return {
         // state items
-        currentUser: state.authReducer.currentUser
+        currentUser: state.authReducer.currentUser,
+        userChecked: state.authReducer.userChecked,
     }
 }
 
 export default withRouter(connect(mapStateToProps, {
     // actions
+    updateUserProfile,
     
 })(withStyles(styles)(Account)));

--- a/src/components/Account.js
+++ b/src/components/Account.js
@@ -137,6 +137,10 @@ class Account extends React.Component {
             <div>
                 <Typography variant = 'h2'>Account</Typography>
                 {(this.props.userChecked && this.props.currentUser) ? (
+                    <div>
+                        {this.props.currentUser.auth_provider === 'auth0' ? (
+
+                        
                      <Card className = {classes.card}>
                      <CardActionArea>
                          <CardMedia className = {classes.media} 
@@ -220,9 +224,41 @@ class Account extends React.Component {
  
  
                  </Card>
-                ) : <h1>Lodaing...</h1>}
-               
+                 ) : (
+                    <div>
+                        <Card className = {classes.card}>
+                     <CardActionArea>
+                         <CardMedia className = {classes.media} 
+                         image = {this.props.currentUser.img_url} 
+                         title = 'Profile Picture'/>
+                     </CardActionArea>
+                     <CardContent>
+                        <Typography variant = 'overline'>Username</Typography>
+                        <Typography variant = 'h6'>{this.props.currentUser.user_name}</Typography>
+                        
 
+                        <Typography variant = 'overline'>Email</Typography>
+                        <Typography variant = 'h6'>{this.props.currentUser.email}</Typography>
+
+                        <Typography variant = 'overline'>Account Type</Typography>
+                        <Typography variant = 'h6'>{this.props.currentUser.role}</Typography>
+
+                        <Typography variant = 'overline'>Login Provider</Typography>
+                        <Typography variant = 'h6'>{this.props.currentUser.auth_provider}</Typography>
+                        <br></br>
+                        <Typography variant = 'subtitle2' color = 'textSecondary'>Because you are logged in via a social login provider, your user profile data is read-only.</Typography>
+                        
+                     </CardContent>
+ 
+                 </Card>
+                    </div>
+                )}
+
+                 </div>
+                ) : <h1>Loading...</h1>}
+               
+            
+            
 
             </div>
         )

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -30,7 +30,7 @@ import Fab from '@material-ui/core/Fab';
 import AddIcon from '@material-ui/icons/Add';
 
 // Actions
-import { getUserProperties } from '../actions';
+import { getUserProperties, getCleaners } from '../actions';
 import PropertyPreview from './PropertyPreview';
 
 const TopBar = styled.div`
@@ -64,9 +64,13 @@ class Properties extends React.Component {
 		this.props.getUserProperties();
 	}
 
-	componentDidUpdate() {
-		if (this.props.refreshProperties) {
+	componentDidUpdate(prevProps) {
+		if (prevProps.refreshProperties !== this.props.refreshProperties) {
 			this.props.getUserProperties();
+		}
+
+		if(prevProps.refreshCleaners !== this.props.refreshCleaners){
+			this.props.getCleaners();
 		}
 	}
 
@@ -153,7 +157,8 @@ const mapStateToProps = state => {
 		properties: state.propertyReducer.properties,
 		refreshProperties: state.propertyReducer.refreshProperties,
 		cleaners: state.propertyReducer.cleaners,
-		userInfo: state.authReducer.userInfo
+		userInfo: state.authReducer.userInfo,
+		refreshCleaners: state.propertyReducer.refreshCleaners
 	};
 };
 
@@ -162,7 +167,8 @@ export default withRouter(
 		mapStateToProps,
 		{
 			// actions
-			getUserProperties
+			getUserProperties,
+			getCleaners,
 		}
 	)(withStyles(styles)(Properties))
 );

--- a/src/components/__App/App.js
+++ b/src/components/__App/App.js
@@ -33,7 +33,7 @@ const ComponentContainer = styled.div`
 class App extends Component {
 	componentDidMount() {
 		if (!this.props.userInfo) {
-			this.props.checkIfUserExists(null);
+			this.props.checkIfUserExists(localStorage.getItem('accountType') || localStorage.getItem('role'));
 		}
 	}
 

--- a/src/reducers/authReducer.js
+++ b/src/reducers/authReducer.js
@@ -1,4 +1,4 @@
-import { USER_CHECKED } from '../actions';
+import { USER_CHECKED, USER_UPDATED, UPDATING_USER } from '../actions';
 
 const initialState = {
 	userInfo: null,
@@ -11,6 +11,20 @@ const authReducer = (state = initialState, action) => {
 		// example action
 		case USER_CHECKED:
 			return { ...state, userInfo: action.payload.userInfo, userChecked: true, currentUser: action.payload.user };
+		
+		case UPDATING_USER:
+			return {
+				...state,
+				userChecked: false,
+			}
+
+		case USER_UPDATED:
+			return  {
+				...state,
+				userInfo: action.payload.userInfo,
+				currentUser: action.payload.user,
+				userChecked: true,
+			}
 
 		default:
 			return state;

--- a/src/reducers/authReducer.js
+++ b/src/reducers/authReducer.js
@@ -2,14 +2,15 @@ import { USER_CHECKED } from '../actions';
 
 const initialState = {
 	userInfo: null,
-	userChecked: null
+	userChecked: null,
+	currentUser: null,
 };
 
 const authReducer = (state = initialState, action) => {
 	switch (action.type) {
 		// example action
 		case USER_CHECKED:
-			return { ...state, userInfo: action.payload, userChecked: true };
+			return { ...state, userInfo: action.payload.userInfo, userChecked: true, currentUser: action.payload.user };
 
 		default:
 			return state;

--- a/src/reducers/propertyReducer.js
+++ b/src/reducers/propertyReducer.js
@@ -1,3 +1,4 @@
+
 import {
 	// FETCHING_PROPERTIES,
 	PROPERTIES_FETCHED,
@@ -35,13 +36,13 @@ const propertyReducer = (state = initialState, action) => {
 			};
 
 		case PROPERTIES_FETCHED:
-			return { ...state, properties: action.payload, refreshProperties: false };
+			return { ...state, properties: action.payload, refreshProperties: false, refreshCleaners: true };
 
 		case PROPERTY_ADDED:
 			return { ...state, refreshProperties: true };
 
 		case CLEANERS_FETCHED:
-			return { ...state, cleaners: action.payload };
+			return { ...state, cleaners: action.payload, refreshCleaners: false };
 
 		case CLEANER_UPDATED:
 			return {...state, refreshCleaners: true}


### PR DESCRIPTION
This gives us an account page to view and manage user profile information.

Any account registered via social login will have their account profile set as read-only, and any user that signs up via email and password can manage their username, email, and passwords all from our account management page.

Currently, the auth0 API management token is set within the backend .env file. This will eventually need to be generated programmatically, but for testing purposes this is sufficient for now.

User interactions are conditionally rendered based on which field they wish to edit, and I've tested to ensure that the re-rendering occurs properly once the update is executed.

**NOTE: This will require a re-migration, since we are adding a field to the users table to keep track of the user's `auth_provider`.**