### PR TITLE
Add property info to guests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"autosuggest-highlight": "^3.1.1",
 		"axios": "^0.18.0",
 		"mailgun-js": "^0.22.0",
+		"moment": "^2.24.0",
 		"react": "^16.8.6",
 		"react-autosuggest": "^9.4.3",
 		"react-dom": "^16.8.6",

--- a/src/actions/guestActions.js
+++ b/src/actions/guestActions.js
@@ -10,6 +10,11 @@ export const UPDATING_GUEST_TASK = 'UPDATING_GUEST_TASK';
 export const UPDATED_GUEST_TASK = 'UPDATED_GUEST_TASK';
 export const UPDATE_GUEST_TASK_ERROR = 'UPDATE_GUEST_TASK_ERROR';
 
+// reassignCleaner
+export const REQUESTING_REASSIGNMENT = 'REQUESTING_REASSIGNMENT';
+export const REQUESTED_REASSIGNMENT = 'REQUESTED_REASSIGNMENT';
+export const REQUEST_REASSIGNMENT_ERROR = 'REQUEST_REASSIGNMENT_ERROR';
+
 const backendUrl = process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`;
 
 export const getGuest = guest_id => {
@@ -58,6 +63,36 @@ export const updateGuestTask = (guest_id, task_id, completed) => {
 			.catch(error => {
 				console.log(error);
 				dispatch({ type: UPDATE_GUEST_TASK_ERROR, payload: error });
+			});
+	};
+};
+
+export const reassignCleaner = (guest_id, cleaner_id) => {
+	const token = localStorage.getItem('jwt');
+	const userInfo = localStorage.getItem('userInfo');
+
+	const options = {
+		headers: { Authorization: `Bearer ${token}`, 'user-info': userInfo }
+	};
+
+	return dispatch => {
+		dispatch({ type: REQUESTING_REASSIGNMENT });
+
+		axios
+			.post(
+				`${backendUrl}/api/guests/${guest_id}/reassign/${cleaner_id}`,
+				{},
+				options
+			)
+			.then(res => {
+				dispatch({ type: REQUESTED_REASSIGNMENT, payload: res.data });
+
+				return dispatch(getGuest(guest_id));
+			})
+
+			.catch(error => {
+				console.log(error);
+				dispatch({ type: REQUEST_REASSIGNMENT_ERROR, payload: error });
 			});
 	};
 };

--- a/src/components/GuestList.js
+++ b/src/components/GuestList.js
@@ -18,7 +18,7 @@ const GuestList = props => {
 			<Typography variant="h6" className={classes.title}>
 				{listTitle}
 			</Typography>
-			<List className={classes.root}>
+			<List className={classes.checkList}>
 				{taskList.map(({ task_id, text, completed }) => (
 					<ListItem
 						role={undefined}

--- a/src/components/Property.js
+++ b/src/components/Property.js
@@ -241,7 +241,7 @@ const Property = props => {
 					</Typography>
 
 					<Typography variant="h6">
-						{props.gettingProperty
+						{props.gettingProperty && !props.property.address
 							? 'Loading...'
 							: props.getPropertyError
 							? 'Error'
@@ -267,9 +267,11 @@ const Property = props => {
 				</BeforeAndDuringColumn>
 
 				<AfterColumn>
-					<Typography variant="h6" className={classes.title}>
-						After Stay
-					</Typography>
+					{!!afterStay.length && (
+						<Typography variant="h6" className={classes.title}>
+							After Stay
+						</Typography>
+					)}
 
 					{afterStay.map(
 						(taskList, deadline) =>

--- a/src/components/Property.js
+++ b/src/components/Property.js
@@ -26,9 +26,6 @@ import Paper from '@material-ui/core/Paper';
 
 import Typography from '@material-ui/core/Typography';
 
-import IconButton from '@material-ui/core/IconButton';
-import AddCircle from '@material-ui/icons/AddCircle';
-
 import Autosuggest from 'react-autosuggest';
 import match from 'autosuggest-highlight/match';
 import parse from 'autosuggest-highlight/parse';
@@ -179,7 +176,7 @@ const Property = props => {
 		setSuggestions([]);
 	};
 
-	const handleChange = () => (event, { newValue }) => {
+	const handleChange = (event, { newValue }) => {
 		setNewTask(newValue);
 	};
 
@@ -194,8 +191,6 @@ const Property = props => {
 
 	const handleSubmit = (newTask, deadline) => {
 		props.addTask(props.property.property_id, newTask, deadline);
-
-		setNewDeadline(null);
 
 		// at the moment, errors eat your input with no feedback
 	};
@@ -306,14 +301,20 @@ const Property = props => {
 						}}
 					/>
 					{newDeadline && (
-						<form onSubmit={() => handleSubmit(newTask, newDeadline.value)}>
+						<form
+							onSubmit={() => {
+								handleSubmit(newTask, newDeadline.value);
+								setNewDeadline(null);
+							}}
+						>
+							{/* onChange is kinda choppy here compared to the other lists. Not sure why. */}
 							<Autosuggest
 								{...autosuggestProps}
 								inputProps={{
 									classes,
 									placeholder: 'Add a task',
 									value: newTask,
-									onChange: handleChange('newTask'),
+									onChange: handleChange,
 									autoFocus: true,
 									onBlur: () => setNewDeadline(null),
 									onKeyDown: e => {

--- a/src/components/Property.js
+++ b/src/components/Property.js
@@ -162,10 +162,9 @@ function getSuggestionValue(suggestion) {
 const Property = props => {
 	const classes = useStyles();
 
-	const [newTaskDeadline, setNewTaskDeadline] = useState(null);
-	const [state, setState] = useState({ newTask: '' });
+	const [newTask, setNewTask] = useState('');
+	const [newDeadline, setNewDeadline] = React.useState(null);
 	const [stateSuggestions, setSuggestions] = React.useState([]);
-	const [newDeadline, setnewDeadline] = React.useState(null);
 
 	useEffect(() => {
 		props.getProperty(props.match.params.property_id);
@@ -180,11 +179,8 @@ const Property = props => {
 		setSuggestions([]);
 	};
 
-	const handleChange = name => (event, { newValue }) => {
-		setState({
-			...state,
-			[name]: newValue
-		});
+	const handleChange = () => (event, { newValue }) => {
+		setNewTask(newValue);
 	};
 
 	const autosuggestProps = {
@@ -199,7 +195,7 @@ const Property = props => {
 	const handleSubmit = (newTask, deadline) => {
 		props.addTask(props.property.property_id, newTask, deadline);
 
-		setnewDeadline(null);
+		setNewDeadline(null);
 
 		// at the moment, errors eat your input with no feedback
 	};
@@ -305,49 +301,39 @@ const Property = props => {
 							option => !afterStay[+option.value]
 						)}
 						onChange={option => {
-							setnewDeadline(option);
+							setNewDeadline(option);
+							setNewTask('');
 						}}
 					/>
-					{newDeadline &&
-						(newTaskDeadline === newDeadline.value ? (
-							<form onSubmit={handleSubmit}>
-								<Autosuggest
-									{...autosuggestProps}
-									inputProps={{
-										classes,
-										placeholder: 'Add a task',
-										value: state.newTask,
-										onChange: handleChange('newTask'),
-										autoFocus: true,
-										onBlur: () => setNewTaskDeadline(null),
-										onKeyDown: e => {
-											if (e.key === 'Escape') setNewTaskDeadline(null);
-										}
-									}}
-									theme={{
-										container: classes.container,
-										suggestionsContainerOpen: classes.suggestionsContainerOpen,
-										suggestionsList: classes.suggestionsList,
-										suggestion: classes.suggestion
-									}}
-									renderSuggestionsContainer={options => (
-										<Paper {...options.containerProps} square>
-											{options.children}
-										</Paper>
-									)}
-								/>
-							</form>
-						) : (
-							<IconButton
-								aria-label="AddCircle"
-								onClick={() => {
-									setNewTaskDeadline(newDeadline.value);
-									setState({ newTask: '' });
+					{newDeadline && (
+						<form onSubmit={() => handleSubmit(newTask, newDeadline.value)}>
+							<Autosuggest
+								{...autosuggestProps}
+								inputProps={{
+									classes,
+									placeholder: 'Add a task',
+									value: newTask,
+									onChange: handleChange('newTask'),
+									autoFocus: true,
+									onBlur: () => setNewDeadline(null),
+									onKeyDown: e => {
+										if (e.key === 'Escape') setNewDeadline(null);
+									}
 								}}
-							>
-								<AddCircle className={classes.icon} style={{ fontSize: 30 }} />
-							</IconButton>
-						))}
+								theme={{
+									container: classes.container,
+									suggestionsContainerOpen: classes.suggestionsContainerOpen,
+									suggestionsList: classes.suggestionsList,
+									suggestion: classes.suggestion
+								}}
+								renderSuggestionsContainer={options => (
+									<Paper {...options.containerProps} square>
+										{options.children}
+									</Paper>
+								)}
+							/>
+						</form>
+					)}
 				</AfterColumn>
 			</PropertyContainer>
 		</React.Fragment>

--- a/src/reducers/guestReducer.js
+++ b/src/reducers/guestReducer.js
@@ -4,7 +4,10 @@ import {
 	GET_GUEST_ERROR,
 	UPDATING_GUEST_TASK,
 	UPDATED_GUEST_TASK,
-	UPDATE_GUEST_TASK_ERROR
+	UPDATE_GUEST_TASK_ERROR,
+	REQUESTING_REASSIGNMENT,
+	REQUESTED_REASSIGNMENT,
+	REQUEST_REASSIGNMENT_ERROR
 } from '../actions';
 
 const initialState = {
@@ -50,6 +53,25 @@ const guestReducer = (state = initialState, action) => {
 				...state,
 				updatingGuestTask: undefined,
 				updateGuestTaskError: action.payload
+			};
+
+		case REQUESTING_REASSIGNMENT:
+			return {
+				...state,
+				requestingReassignment: true
+			};
+
+		case REQUESTED_REASSIGNMENT:
+			return {
+				...state,
+				requestingReassignment: undefined
+			};
+
+		case REQUEST_REASSIGNMENT_ERROR:
+			return {
+				...state,
+				requestingReassignment: undefined,
+				requestReassignmentError: action.payload
 			};
 
 		default:

--- a/yarn.lock
+++ b/yarn.lock
@@ -6879,6 +6879,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   dependencies:
     minimist "0.0.8"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"


### PR DESCRIPTION
Adds the property info component to the guest page.
Also enables cleaner reassignment.
As a manager, reassignment is instant.
As an assistant, reassignment takes the form of a request.

Todo:
Show pending reassignments (already provided by the backend)
Style react-select options differently based on cleaner availability. Help me out with this one.