### PR TITLE
Guests page and API interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,19 @@
 		"not op_mini all"
 	],
 	"dependencies": {
+		"@date-io/core": "^1.3.6",
+		"@date-io/moment": "^1.3.6",
 		"@material-ui/core": "^4.0.1",
 		"@material-ui/icons": "^4.0.1",
+		"@material-ui/pickers": "^3.0.0",
 		"auth0-js": "^9.10.4",
 		"auth0-lock": "^11.16.0",
 		"autosuggest-highlight": "^3.1.1",
 		"axios": "^0.18.0",
 		"mailgun-js": "^0.22.0",
+		"moment": "^2.24.0",
+		"prop-types": "^15.7.2",
+		"proptypes": "^1.1.0",
 		"react": "^16.8.6",
 		"react-autosuggest": "^9.4.3",
 		"react-dom": "^16.8.6",
@@ -35,6 +41,7 @@
 		"redux": "^4.0.1",
 		"redux-logger": "^3.0.6",
 		"redux-thunk": "^2.3.0",
-		"styled-components": "^4.2.0"
+		"styled-components": "^4.2.0",
+		"typescript": "^3.5.1"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
 		"mailgun-js": "^0.22.0",
 		"moment": "^2.24.0",
 		"prop-types": "^15.7.2",
-		"proptypes": "^1.1.0",
 		"react": "^16.8.6",
 		"react-autosuggest": "^9.4.3",
 		"react-dom": "^16.8.6",

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -15,6 +15,7 @@ export const checkIfUserExists = (role) => {
     // The role selected by the user is passed upon account validation.
 
     let token = localStorage.getItem('jwt');
+    console.log('login attempt');
 
     let options = {
         headers: {

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -14,15 +14,15 @@ export const checkIfUserExists = (role) => {
 
     // The role selected by the user is passed upon account validation.
 
-    let token = localStorage.getItem('jwt');
+    const token = localStorage.getItem('jwt');
 
-    let options = {
+    const options = {
         headers: {
             Authorization: `Bearer ${token}`,
         }
     }
 
-    let body = {
+    const body = {
         role: role,
     }
 

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -15,7 +15,6 @@ export const checkIfUserExists = (role) => {
     // The role selected by the user is passed upon account validation.
 
     let token = localStorage.getItem('jwt');
-    console.log('login attempt');
 
     let options = {
         headers: {

--- a/src/actions/guestActions.js
+++ b/src/actions/guestActions.js
@@ -72,9 +72,7 @@ export const fetchAllGuests = () => {
 		dispatch({type: FETCHING_GUESTS});
 
 		endpoint.then(res => {
-			console.log(res.data, 'fetch guests res');
-			dispatch({type: GUESTS_FETCHED, payload: res.data.guests});
-	
+			dispatch({type: GUESTS_FETCHED, payload: res.data.guests})
 		}).catch(error => {
 			console.log(error);
 			dispatch({type: ERROR});

--- a/src/actions/guestActions.js
+++ b/src/actions/guestActions.js
@@ -10,6 +10,10 @@ export const UPDATING_GUEST_TASK = 'UPDATING_GUEST_TASK';
 export const UPDATED_GUEST_TASK = 'UPDATED_GUEST_TASK';
 export const UPDATE_GUEST_TASK_ERROR = 'UPDATE_GUEST_TASK_ERROR';
 
+export const FETCHING_GUESTS = 'FETCHING_GUESTS';
+export const GUESTS_FETCHED = 'GUESTS_FETCHED';
+export const ERROR = 'ERROR';
+
 const backendUrl = process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`;
 
 export const getGuest = guest_id => {
@@ -61,3 +65,27 @@ export const updateGuestTask = (guest_id, task_id, completed) => {
 			});
 	};
 };
+
+export const fetchAllGuests = () => {
+	const token = localStorage.getItem('jwt');
+	const userInfo = localStorage.getItem('userInfo');
+
+	const options = {
+		headers: { Authorization: `Bearer ${token}`, 'user-info': userInfo }
+	};
+
+	const endpoint = axios.get(`${backendUrl}/api/guests`, options);
+
+	return dispatch => {
+		dispatch({type: FETCHING_GUESTS});
+
+		endpoint.then(res => {
+			console.log(res);
+			dispatch({type: GUESTS_FETCHED, payload: res.data.guests});
+	
+		}).catch(error => {
+			console.log(error);
+			dispatch({type: ERROR});
+		})
+	}
+}

--- a/src/actions/guestActions.js
+++ b/src/actions/guestActions.js
@@ -16,13 +16,14 @@ export const ERROR = 'ERROR';
 
 const backendUrl = process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`;
 
-export const getGuest = guest_id => {
-	const token = localStorage.getItem('jwt');
-	const userInfo = localStorage.getItem('userInfo');
+const token = localStorage.getItem('jwt');
+const userInfo = localStorage.getItem('userInfo');
 
-	const options = {
-		headers: { Authorization: `Bearer ${token}`, 'user-info': userInfo }
-	};
+const options = {
+	headers: { Authorization: `Bearer ${token}`, 'user-info': userInfo }
+};
+
+export const getGuest = guest_id => {
 
 	return dispatch => {
 		dispatch({ type: GETTING_GUEST });
@@ -40,12 +41,6 @@ export const getGuest = guest_id => {
 };
 
 export const updateGuestTask = (guest_id, task_id, completed) => {
-	const token = localStorage.getItem('jwt');
-	const userInfo = localStorage.getItem('userInfo');
-
-	const options = {
-		headers: { Authorization: `Bearer ${token}`, 'user-info': userInfo }
-	};
 
 	return dispatch => {
 		dispatch({ type: UPDATING_GUEST_TASK });
@@ -67,12 +62,6 @@ export const updateGuestTask = (guest_id, task_id, completed) => {
 };
 
 export const fetchAllGuests = () => {
-	const token = localStorage.getItem('jwt');
-	const userInfo = localStorage.getItem('userInfo');
-
-	const options = {
-		headers: { Authorization: `Bearer ${token}`, 'user-info': userInfo }
-	};
 
 	const endpoint = axios.get(`${backendUrl}/api/guests`, options);
 
@@ -88,4 +77,8 @@ export const fetchAllGuests = () => {
 			dispatch({type: ERROR});
 		})
 	}
+}
+
+export const addGuest = (guest) => {
+
 }

--- a/src/actions/guestActions.js
+++ b/src/actions/guestActions.js
@@ -14,6 +14,9 @@ export const FETCHING_GUESTS = 'FETCHING_GUESTS';
 export const GUESTS_FETCHED = 'GUESTS_FETCHED';
 export const ERROR = 'ERROR';
 
+export const ADDING_GUEST = 'ADDING_GUEST';
+export const GUEST_ADDED = 'GUEST_ADDED';
+
 const backendUrl = process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`;
 
 const token = localStorage.getItem('jwt');
@@ -69,7 +72,7 @@ export const fetchAllGuests = () => {
 		dispatch({type: FETCHING_GUESTS});
 
 		endpoint.then(res => {
-			console.log(res);
+			console.log(res.data, 'fetch guests res');
 			dispatch({type: GUESTS_FETCHED, payload: res.data.guests});
 	
 		}).catch(error => {
@@ -79,6 +82,19 @@ export const fetchAllGuests = () => {
 	}
 }
 
-export const addGuest = (guest) => {
+export const addGuest = (property_id, guest) => {
 
+	const endpoint = axios.post(`${backendUrl}/api/guests/${property_id}`, guest, options);
+
+	return dispatch => {
+		dispatch({type: ADDING_GUEST});
+
+		endpoint.then(res => {
+			console.log(res.data, 'add guest res');
+			dispatch({type: GUEST_ADDED, payload: res.data}) // payload is new guest ID
+		}).catch(error => {
+			console.log(error);
+			dispatch({type: ERROR});
+		})
+	}
 }

--- a/src/actions/guestActions.js
+++ b/src/actions/guestActions.js
@@ -19,14 +19,23 @@ export const GUEST_ADDED = 'GUEST_ADDED';
 
 const backendUrl = process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`;
 
-const token = localStorage.getItem('jwt');
-const userInfo = localStorage.getItem('userInfo');
 
-const options = {
-	headers: { Authorization: `Bearer ${token}`, 'user-info': userInfo }
-};
+function setHeaders(){
+	const token = localStorage.getItem('jwt');
+	const userInfo = localStorage.getItem('userInfo');
+	
+	const options = {
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'user-info': userInfo
+		}
+	};
+
+	return options;
+}
 
 export const getGuest = guest_id => {
+	let options = setHeaders();
 
 	return dispatch => {
 		dispatch({ type: GETTING_GUEST });
@@ -44,6 +53,7 @@ export const getGuest = guest_id => {
 };
 
 export const updateGuestTask = (guest_id, task_id, completed) => {
+	let options = setHeaders();
 
 	return dispatch => {
 		dispatch({ type: UPDATING_GUEST_TASK });
@@ -65,6 +75,7 @@ export const updateGuestTask = (guest_id, task_id, completed) => {
 };
 
 export const fetchAllGuests = () => {
+	let options = setHeaders();
 
 	const endpoint = axios.get(`${backendUrl}/api/guests`, options);
 
@@ -81,6 +92,7 @@ export const fetchAllGuests = () => {
 }
 
 export const addGuest = (property_id, guest) => {
+	let options = setHeaders();
 
 	const endpoint = axios.post(`${backendUrl}/api/guests/${property_id}`, guest, options);
 

--- a/src/actions/propertyActions.js
+++ b/src/actions/propertyActions.js
@@ -30,22 +30,21 @@ export const DELETE_TASK_ERROR = 'DELETE_TASK_ERROR';
 
 const backendUrl = process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`;
 
+let token = localStorage.getItem('jwt');
+let userInfo = localStorage.getItem('userInfo');
+
+let options = {
+    headers: {
+        Authorization: `Bearer ${token}`,
+        'user-info': userInfo
+    }
+};
+
 export const getUserProperties = () => {
 	// This function passes the auth0 jwt to the backend, and validates whether an entry
 	// for this user exists in the database.
 
 	// The role selected by the user is passed upon account validation.
-
-	let token = localStorage.getItem('jwt');
-	let userInfo = localStorage.getItem('userInfo');
-
-	let options = {
-		headers: {
-			Authorization: `Bearer ${token}`,
-			'user-info': userInfo
-		}
-	};
-
 	const fetchUrl = axios.get(`${backendUrl}/api/properties`, options);
 
 	return dispatch => {
@@ -65,12 +64,6 @@ export const getUserProperties = () => {
 };
 
 export const getProperty = property_id => {
-	const token = localStorage.getItem('jwt');
-	const userInfo = localStorage.getItem('userInfo');
-
-	const options = {
-		headers: { Authorization: `Bearer ${token}`, 'user-info': userInfo }
-	};
 
 	return dispatch => {
 		dispatch({ type: GETTING_PROPERTY });
@@ -88,15 +81,6 @@ export const getProperty = property_id => {
 };
 
 export const addProperty = property => {
-	let token = localStorage.getItem('jwt');
-	let userInfo = localStorage.getItem('userInfo');
-
-	let options = {
-		headers: {
-			Authorization: `Bearer ${token}`,
-			'user-info': userInfo
-		}
-	};
 
 	const endpoint = axios.post(
 		`${backendUrl}/api/properties`,
@@ -121,15 +105,6 @@ export const addProperty = property => {
 };
 
 export const getCleaners = () => {
-	let token = localStorage.getItem('jwt');
-	let userInfo = localStorage.getItem('userInfo');
-
-	let options = {
-		headers: {
-			Authorization: `Bearer ${token}`,
-			'user-info': userInfo
-		}
-	};
 
 	const endpoint = axios.get(`${backendUrl}/api/cleaners`, options);
 
@@ -154,16 +129,6 @@ export const getCleaners = () => {
 
 export const getPartners = () => {
 
-    let token = localStorage.getItem('jwt');
-    let userInfo = localStorage.getItem('userInfo');
-
-    let options = {
-        headers: {
-            Authorization: `Bearer ${token}`,
-            'user-info': userInfo,
-        }
-    }
-
     const endpoint = axios.get(`${backendUrl}/api/cleaners/partners`, options);
 
     return dispatch => {
@@ -179,15 +144,6 @@ export const getPartners = () => {
 }
 
 export const changeAvailableCleaner = (property_id, cleaner_id, available) =>{
-	let token = localStorage.getItem('jwt');
-    let userInfo = localStorage.getItem('userInfo');
-
-    let options = {
-        headers: {
-            Authorization: `Bearer ${token}`,
-            'user-info': userInfo,
-        }
-    }
 
     const endpoint = axios.put(`${backendUrl}/api/properties/${property_id}/available/${cleaner_id}`, {available}, options)
 
@@ -208,16 +164,6 @@ export const changeAvailableCleaner = (property_id, cleaner_id, available) =>{
 
 export const changeCleaner = (property_id, cleaner_id) => {
 
-    let token = localStorage.getItem('jwt');
-    let userInfo = localStorage.getItem('userInfo');
-
-    let options = {
-        headers: {
-            Authorization: `Bearer ${token}`,
-            'user-info': userInfo,
-        }
-    }
-
     const endpoint = axios.put(`${backendUrl}/api/cleaners/update/${property_id}`, {cleaner_id}, options)
 
     return dispatch => {
@@ -236,12 +182,6 @@ export const changeCleaner = (property_id, cleaner_id) => {
 
 // Tasks
 export const addTask = (property_id, text, deadline) => {
-	const token = localStorage.getItem('jwt');
-	const userInfo = localStorage.getItem('userInfo');
-
-	const options = {
-		headers: { Authorization: `Bearer ${token}`, 'user-info': userInfo }
-	};
 
 	return dispatch => {
 		dispatch({ type: ADDING_TASK });
@@ -263,12 +203,6 @@ export const addTask = (property_id, text, deadline) => {
 };
 
 export const deleteTask = task_id => {
-	const token = localStorage.getItem('jwt');
-	const userInfo = localStorage.getItem('userInfo');
-
-	const options = {
-		headers: { Authorization: `Bearer ${token}`, 'user-info': userInfo }
-	};
 
 	return dispatch => {
 		dispatch({ type: DELETING_TASK });

--- a/src/actions/propertyActions.js
+++ b/src/actions/propertyActions.js
@@ -42,7 +42,7 @@ let options = {
 
 export const getUserProperties = () => {
 	// This function passes the auth0 jwt to the backend, and validates whether an entry
-	// for this user exists in the database.
+    // for this user exists in the database.
 
 	// The role selected by the user is passed upon account validation.
 	const fetchUrl = axios.get(`${backendUrl}/api/properties`, options);
@@ -113,7 +113,6 @@ export const getCleaners = () => {
 
 		endpoint
 			.then(res => {
-				console.log('get cleaners', res.data);
 
 				dispatch({
 					type: CLEANERS_FETCHED,
@@ -151,7 +150,6 @@ export const changeAvailableCleaner = (property_id, cleaner_id, available) =>{
         dispatch({type: UPDATING_CLEANER});
 
         endpoint.then(res => {
-            console.log('cleaner update', res.data);
 
 				dispatch({ type: CLEANER_UPDATED, paload: res.data.updated });
 			})
@@ -170,7 +168,6 @@ export const changeCleaner = (property_id, cleaner_id) => {
         dispatch({type: UPDATING_CLEANER});
 
         endpoint.then(res => {
-            console.log('cleaner update', res.data);
 
             dispatch({type: CLEANER_UPDATED, payload: res.data.updated});
         }).catch(err => {

--- a/src/actions/propertyActions.js
+++ b/src/actions/propertyActions.js
@@ -28,23 +28,33 @@ export const DELETING_TASK = 'DELETING_TASK';
 export const DELETED_TASK = 'DELETED_TASK';
 export const DELETE_TASK_ERROR = 'DELETE_TASK_ERROR';
 
+
+function setHeaders(){
+	const token = localStorage.getItem('jwt');
+	const userInfo = localStorage.getItem('userInfo');
+	
+	const options = {
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'user-info': userInfo
+		}
+	};
+
+	return options;
+}
+
 const backendUrl = process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`;
 
-const token = localStorage.getItem('jwt');
-const userInfo = localStorage.getItem('userInfo');
 
-const options = {
-    headers: {
-        Authorization: `Bearer ${token}`,
-        'user-info': userInfo
-    }
-};
 
 export const getUserProperties = () => {
 	// This function passes the auth0 jwt to the backend, and validates whether an entry
     // for this user exists in the database.
 
 	// The role selected by the user is passed upon account validation.
+	
+	let options = setHeaders();
+
 	const fetchUrl = axios.get(`${backendUrl}/api/properties`, options);
 
 	return dispatch => {
@@ -65,6 +75,8 @@ export const getUserProperties = () => {
 
 export const getProperty = property_id => {
 
+	let options = setHeaders();
+
 	return dispatch => {
 		dispatch({ type: GETTING_PROPERTY });
 
@@ -81,6 +93,8 @@ export const getProperty = property_id => {
 };
 
 export const addProperty = property => {
+
+	let options = setHeaders();
 
 	const endpoint = axios.post(
 		`${backendUrl}/api/properties`,
@@ -106,6 +120,8 @@ export const addProperty = property => {
 
 export const getCleaners = () => {
 
+	let options = setHeaders();
+
 	const endpoint = axios.get(`${backendUrl}/api/cleaners`, options);
 
 	return dispatch => {
@@ -128,6 +144,8 @@ export const getCleaners = () => {
 
 export const getPartners = () => {
 
+	let options = setHeaders();
+
     const endpoint = axios.get(`${backendUrl}/api/cleaners/partners`, options);
 
     return dispatch => {
@@ -143,6 +161,8 @@ export const getPartners = () => {
 }
 
 export const changeAvailableCleaner = (property_id, cleaner_id, available) =>{
+
+	let options = setHeaders();
 
     const endpoint = axios.put(`${backendUrl}/api/properties/${property_id}/available/${cleaner_id}`, {available}, options)
 
@@ -161,8 +181,9 @@ export const changeAvailableCleaner = (property_id, cleaner_id, available) =>{
 };
 
 export const changeCleaner = (property_id, cleaner_id) => {
-
-    const endpoint = axios.put(`${backendUrl}/api/cleaners/update/${property_id}`, {cleaner_id}, options)
+	let options = setHeaders();
+	
+	const endpoint = axios.put(`${backendUrl}/api/cleaners/update/${property_id}`, {cleaner_id}, options)
 
     return dispatch => {
         dispatch({type: UPDATING_CLEANER});
@@ -179,6 +200,8 @@ export const changeCleaner = (property_id, cleaner_id) => {
 
 // Tasks
 export const addTask = (property_id, text, deadline) => {
+
+	let options = setHeaders();
 
 	return dispatch => {
 		dispatch({ type: ADDING_TASK });
@@ -200,6 +223,8 @@ export const addTask = (property_id, text, deadline) => {
 };
 
 export const deleteTask = task_id => {
+
+	let options = setHeaders();
 
 	return dispatch => {
 		dispatch({ type: DELETING_TASK });

--- a/src/actions/propertyActions.js
+++ b/src/actions/propertyActions.js
@@ -30,10 +30,10 @@ export const DELETE_TASK_ERROR = 'DELETE_TASK_ERROR';
 
 const backendUrl = process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`;
 
-let token = localStorage.getItem('jwt');
-let userInfo = localStorage.getItem('userInfo');
+const token = localStorage.getItem('jwt');
+const userInfo = localStorage.getItem('userInfo');
 
-let options = {
+const options = {
     headers: {
         Authorization: `Bearer ${token}`,
         'user-info': userInfo

--- a/src/components/Account.js
+++ b/src/components/Account.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 // Router
 import {withRouter} from 'react-router-dom';
 
-import {updateUserProfile} from '../actions/index';
+import {updateUserProfile, checkIfUserExists} from '../actions/index';
 
 // FlexBox
 
@@ -49,6 +49,10 @@ const styles = {
 }
 
 class Account extends React.Component {
+
+    componentDidMount(){
+        this.props.checkIfUserExists(localStorage.getItem('role'));
+    }
 
     componentDidUpdate(prevProps){
         if(this.props.userChecked !== prevProps.userChecked){
@@ -254,10 +258,7 @@ class Account extends React.Component {
 
                  </div>
                 ) : <h1>Loading...</h1>}
-               
             
-            
-
             </div>
         )
     }
@@ -275,5 +276,6 @@ const mapStateToProps = state => {
 export default withRouter(connect(mapStateToProps, {
     // actions
     updateUserProfile,
+    checkIfUserExists,
     
 })(withStyles(styles)(Account)));

--- a/src/components/Account.js
+++ b/src/components/Account.js
@@ -197,7 +197,7 @@ class Account extends React.Component {
                         <Typography variant = 'h6'>{this.props.currentUser.role}</Typography>
 
                         <Typography variant = 'overline'>Password</Typography>
-
+                            <br></br>
                         {!this.state.passwordOpen ? (
                             <Button variant = 'contained' color = 'secondary' onClick = {this.toggleInput} name = 'passwordOpen'>
                                 <div style = {{width: '100%'}} className = 'password-btn' name = 'passwordOpen' onClick = {this.toggleInput}>

--- a/src/components/Account.js
+++ b/src/components/Account.js
@@ -12,7 +12,6 @@ import {updateUserProfile} from '../actions/index';
 // Card
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';
-import CardActions from '@material-ui/core/CardActions';
 import CardContent from '@material-ui/core/CardContent';
 import CardMedia from '@material-ui/core/CardMedia';
 import Button from '@material-ui/core/Button';
@@ -23,7 +22,6 @@ import { withStyles } from '@material-ui/core';
 
 // Icons 
 import EditTwoTone from '@material-ui/icons/EditTwoTone';
-import Icon from '@material-ui/core/Icon';
 
 // Styled Components
 import styled from 'styled-components';
@@ -121,7 +119,7 @@ class Account extends React.Component {
             } else {
                 window.alert('Passwords must match! Please re-enter your passwords.');
             }
-        } else if (event.target.name = 'email'){
+        } else if (event.target.name === 'email'){
             /**
              * TODO: MAKE SURE THE EMAIL IS A VALID ADDRESS
              */

--- a/src/components/AddGuestForm.js
+++ b/src/components/AddGuestForm.js
@@ -23,10 +23,11 @@ const styles = {
 		display: 'flex',
 		flexFlow: 'column nowrap',
 		padding: '5%',
-		height: '50vh'
+        height: '70vh',
+        width: '70vw',
 	},
 	formField: {
-		margin: '10px 0px'
+        margin: '10px 0px',
 	},
 	formButton: {
 		margin: '10px 0px'
@@ -34,6 +35,14 @@ const styles = {
 };
 
 class AddGuestForm extends React.Component {
+
+    componentDidMount(){
+        this.setState({
+            checkin: moment(),
+            checkout: moment(),
+        })
+    }
+
 	constructor(props) {
 		super(props);
 
@@ -66,18 +75,21 @@ class AddGuestForm extends React.Component {
             cleaner_id: null
         };
 
-		this.props.addGuest(guestInfo);
-		this.props.close();
+        console.log(guestInfo);
+		// this.props.addGuest(guestInfo);
+		// this.props.close();
     };
     
     handleCheckin = event => {
-        console.log(event._d);
-        let date = event._d;
-        console.log(moment().format(date));
+        this.setState({
+            checkin: event.format(),
+        })
     }
 
     handleCheckout = event => {
-        console.log(moment().format(event._d));
+        this.setState({
+            checkout: event.format(),
+        })
     }
 
 	render() {
@@ -100,33 +112,33 @@ class AddGuestForm extends React.Component {
 						onChange={this.handleInput('guest_name')}
 					/>
 
-                    CHECK-IN
+                    <Typography variant = 'overline'>
+                        Check-In
+                    </Typography>
                     <DateTimePicker
-                        label="DateTimePicker"
                         inputVariant="outlined"
                         name = 'checkin'
                         value={this.state.checkin}
                         onChange={this.handleCheckin}
                     />
 
-                    CHECK OUT
+                    <Typography variant = 'overline'>
+                        Check-Out
+                    </Typography>
                     <DateTimePicker
-                        label="DateTimePicker"
                         inputVariant="outlined"
                         name = 'checkout'
                         value={this.state.checkout}
                         onChange={this.handleCheckout}
                     />
 					
-                    Date Picker goes here
-
 					<Button
 						className={classes.formButton}
 						variant="outlined"
 						color="primary"
 						type="submit"
 					>
-						Submit
+						Add Reservation
 					</Button>
 				</form>
 			</div>
@@ -136,7 +148,10 @@ class AddGuestForm extends React.Component {
 
 const mapStateToProps = state => {
 	return {
-		// state items
+        // state items
+        properties: state.propertyReducer.properties,
+        cleaners: state.propertyReducer.cleaners,
+
 	};
 };
 

--- a/src/components/AddGuestForm.js
+++ b/src/components/AddGuestForm.js
@@ -7,6 +7,10 @@ import { withStyles } from '@material-ui/core';
 
 import { addGuest } from '../actions/index';
 
+import moment from 'moment';
+
+import { DateTimePicker } from "@material-ui/pickers";
+
 // Form Components
 
 import TextField from '@material-ui/core/TextField';
@@ -64,7 +68,17 @@ class AddGuestForm extends React.Component {
 
 		this.props.addGuest(guestInfo);
 		this.props.close();
-	};
+    };
+    
+    handleCheckin = event => {
+        console.log(event._d);
+        let date = event._d;
+        console.log(moment().format(date));
+    }
+
+    handleCheckout = event => {
+        console.log(moment().format(event._d));
+    }
 
 	render() {
 		const { classes } = this.props;
@@ -85,6 +99,24 @@ class AddGuestForm extends React.Component {
 						value={this.state.guest_name}
 						onChange={this.handleInput('guest_name')}
 					/>
+
+                    CHECK-IN
+                    <DateTimePicker
+                        label="DateTimePicker"
+                        inputVariant="outlined"
+                        name = 'checkin'
+                        value={this.state.checkin}
+                        onChange={this.handleCheckin}
+                    />
+
+                    CHECK OUT
+                    <DateTimePicker
+                        label="DateTimePicker"
+                        inputVariant="outlined"
+                        name = 'checkout'
+                        value={this.state.checkout}
+                        onChange={this.handleCheckout}
+                    />
 					
                     Date Picker goes here
 

--- a/src/components/AddGuestForm.js
+++ b/src/components/AddGuestForm.js
@@ -1,0 +1,119 @@
+import React from 'react';
+// import styled from 'styled-components';
+
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router-dom';
+import { withStyles } from '@material-ui/core';
+
+import { addGuest } from '../actions/index';
+
+// Form Components
+
+import TextField from '@material-ui/core/TextField';
+import Button from '@material-ui/core/Button';
+
+import Typography from '@material-ui/core/Typography';
+
+const styles = {
+	container: {
+		display: 'flex',
+		flexFlow: 'column nowrap',
+		padding: '5%',
+		height: '50vh'
+	},
+	formField: {
+		margin: '10px 0px'
+	},
+	formButton: {
+		margin: '10px 0px'
+	}
+};
+
+class AddGuestForm extends React.Component {
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			addModal: false,
+			guest_name: '',
+			property_id: null,
+			checkin: null,
+			checkout: null,
+			email: null,
+			cleaner_id: null
+		};
+	}
+
+	handleInput = name => event => {
+		this.setState({
+			[name]: event.target.value
+		});
+	};
+
+	handleSubmit = event => {
+		event.preventDefault();
+
+		const guestInfo = {
+            property_id: null,
+            guest_name: this.state.guest_name,
+            checkin: this.state.checkin,
+            checkout: this.state.checkout,
+            email: this.state.email,
+            cleaner_id: null
+        };
+
+		this.props.addGuest(guestInfo);
+		this.props.close();
+	};
+
+	render() {
+		const { classes } = this.props;
+		return (
+			<div>
+				<form
+					onSubmit={this.handleSubmit}
+					className={classes.container}
+					noValidate
+					autoComplete="off"
+				>
+					<Typography variant="h4">Add a New Guest</Typography>
+
+					<TextField
+						className={classes.formField}
+						id="standard-dense"
+						label="Guest Name"
+						value={this.state.guest_name}
+						onChange={this.handleInput('guest_name')}
+					/>
+					
+                    Date Picker goes here
+
+					<Button
+						className={classes.formButton}
+						variant="outlined"
+						color="primary"
+						type="submit"
+					>
+						Submit
+					</Button>
+				</form>
+			</div>
+		);
+	}
+}
+
+const mapStateToProps = state => {
+	return {
+		// state items
+	};
+};
+
+export default withRouter(
+	connect(
+		mapStateToProps,
+		{
+			// actions
+			addGuest
+		}
+	)(withStyles(styles)(AddGuestForm))
+);

--- a/src/components/AddGuestForm.js
+++ b/src/components/AddGuestForm.js
@@ -15,7 +15,8 @@ import { DateTimePicker } from "@material-ui/pickers";
 
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
-
+import NativeSelect from '@material-ui/core/NativeSelect';
+import Input from '@material-ui/core/Input';
 import Typography from '@material-ui/core/Typography';
 
 const styles = {
@@ -43,6 +44,7 @@ class AddGuestForm extends React.Component {
         })
     }
 
+
 	constructor(props) {
 		super(props);
 
@@ -53,7 +55,9 @@ class AddGuestForm extends React.Component {
 			checkin: null,
 			checkout: null,
 			email: null,
-			cleaner_id: null
+            cleaner_id: null,
+            cleaner: null,
+            property: null,
 		};
 	}
 
@@ -92,6 +96,13 @@ class AddGuestForm extends React.Component {
         })
     }
 
+    handleSelect = name => event => {
+        console.log(event.target.value);
+        this.setState({
+            [name]: event.target.value,
+        })
+    }
+
 	render() {
 		const { classes } = this.props;
 		return (
@@ -103,6 +114,64 @@ class AddGuestForm extends React.Component {
 					autoComplete="off"
 				>
 					<Typography variant="h4">Add a New Guest</Typography>
+
+                    <Typography variant = 'overline'>
+                        Property
+                    </Typography>
+
+                    <NativeSelect
+                        value={this.state.property} // placholder == assigned cleaner's name
+                        onChange={this.handleSelect('property')}
+                        input={
+                            <Input
+                                name="property"
+                                id="property-native-label-placeolder"
+                            />
+                        }
+                    >
+                        <option value = '' >{'(none)'}</option>
+                        {this.props.properties
+                            ? this.props.properties.map(property => {
+                                    return (
+                                        <option value={property} key={property.property_id}>
+                                            {property.property_name}
+                                            {' - '}
+                                            {property.address}
+                                        </option>
+                                    );
+                                })
+                            : null}
+                    </NativeSelect>   
+
+
+                    <Typography variant = 'overline'>
+                        Cleaner
+                    </Typography> 
+
+                        <NativeSelect
+                        value={this.state.cleaner} // placholder == assigned cleaner's name
+                        onChange={this.handleSelect}
+                        input={
+                            <Input
+                                name="cleaner"
+                                id="cleaner-native-label-placeolder"
+                            />
+                        }
+                    >
+                        <option value = '' >{'(none)'}</option>
+                        {this.props.cleaners
+                            ? this.props.cleaners.map(cleaner => {
+                                    return (
+                                        <option value={cleaner} key={cleaner.user_id}>
+                                            {cleaner.user_name}
+                                        </option>
+                                    );
+                                })
+                            : null}
+                    </NativeSelect> 
+
+
+                                        
 
 					<TextField
 						className={classes.formField}

--- a/src/components/AddGuestForm.js
+++ b/src/components/AddGuestForm.js
@@ -71,17 +71,17 @@ class AddGuestForm extends React.Component {
 		event.preventDefault();
 
 		const guestInfo = {
-            property_id: null,
+            property_id: this.state.property_id,
             guest_name: this.state.guest_name,
             checkin: this.state.checkin,
             checkout: this.state.checkout,
-            email: this.state.email,
-            cleaner_id: null
+            email: this.state.email || null,
+            cleaner_id: this.state.cleaner_id,
         };
 
         console.log(guestInfo);
-		// this.props.addGuest(guestInfo);
-		// this.props.close();
+		this.props.addGuest(this.state.property_id, guestInfo);
+		this.props.close();
     };
     
     handleCheckin = event => {
@@ -97,10 +97,21 @@ class AddGuestForm extends React.Component {
     }
 
     handleSelect = name => event => {
-        console.log(event.target.value);
-        this.setState({
-            [name]: event.target.value,
-        })
+        if(name === 'property'){
+            let property = this.props.properties.find(p => p.property_id === event.target.value);
+            this.setState({
+                [name]: property,
+                property_id: event.target.value,
+            })
+        } else if (name === 'cleaner'){
+            let cleaner = this.props.cleaners.find(c => c.cleaner_id === event.target.value);
+            this.setState({
+                [name]: cleaner,
+                cleaner_id: event.target.value
+            })
+        }
+
+        console.log(this.state);
     }
 
 	render() {
@@ -120,7 +131,7 @@ class AddGuestForm extends React.Component {
                     </Typography>
 
                     <NativeSelect
-                        value={this.state.property} // placholder == assigned cleaner's name
+                        value={this.state.property} 
                         onChange={this.handleSelect('property')}
                         input={
                             <Input
@@ -129,11 +140,11 @@ class AddGuestForm extends React.Component {
                             />
                         }
                     >
-                        <option value = '' >{'(none)'}</option>
+                        <option value = {null} >{'Select a Property'}</option>
                         {this.props.properties
                             ? this.props.properties.map(property => {
                                     return (
-                                        <option value={property} key={property.property_id}>
+                                        <option value={property.property_id} key={property.property_id}>
                                             {property.property_name}
                                             {' - '}
                                             {property.address}
@@ -149,8 +160,8 @@ class AddGuestForm extends React.Component {
                     </Typography> 
 
                         <NativeSelect
-                        value={this.state.cleaner} // placholder == assigned cleaner's name
-                        onChange={this.handleSelect}
+                        value={this.state.cleaner} 
+                        onChange={this.handleSelect('cleaner')}
                         input={
                             <Input
                                 name="cleaner"
@@ -158,11 +169,11 @@ class AddGuestForm extends React.Component {
                             />
                         }
                     >
-                        <option value = '' >{'(none)'}</option>
+                        <option value = '' >{'Select a Cleaner'}</option>
                         {this.props.cleaners
                             ? this.props.cleaners.map(cleaner => {
                                     return (
-                                        <option value={cleaner} key={cleaner.user_id}>
+                                        <option value={cleaner.user_id} key={cleaner.user_id}>
                                             {cleaner.user_name}
                                         </option>
                                     );

--- a/src/components/GuestPreview.js
+++ b/src/components/GuestPreview.js
@@ -1,0 +1,46 @@
+// React
+import React from 'react';
+// Redux
+import {connect} from 'react-redux';
+// Router
+import {withRouter} from 'react-router-dom';
+
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+
+class Reports extends React.Component {
+    constructor(props){
+        super(props);
+        this.state = {};
+
+    }
+
+    render(){
+        console.log(this.props.guest);
+        return (
+            <div>
+                Guest Preview
+                <Card>
+                    <CardContent>
+                    preview
+                    </CardContent>
+
+                </Card>
+            </div>
+        )
+    }
+}
+
+
+const mapStateToProps = state => {
+    return {
+        // state items
+    }
+}
+
+export default withRouter(connect(mapStateToProps, {
+    // actions
+    
+})(Reports))
+
+

--- a/src/components/GuestPreview.js
+++ b/src/components/GuestPreview.js
@@ -3,29 +3,68 @@ import React from 'react';
 // Redux
 import {connect} from 'react-redux';
 // Router
-import {withRouter} from 'react-router-dom';
+import {withRouter, Link} from 'react-router-dom';
 
 import Card from '@material-ui/core/Card';
 import CardContent from '@material-ui/core/CardContent';
 
-class Reports extends React.Component {
+import Typography from '@material-ui/core/Typography';
+
+import axios from 'axios';
+
+import moment from 'moment';
+
+const token = localStorage.getItem('jwt');
+const userInfo = localStorage.getItem('userInfo');
+
+const options = {
+	headers: { Authorization: `Bearer ${token}`, 'user-info': userInfo }
+};
+
+const backendUrl = 'http://localhost:5000' || process.env.REACT_APP_BACKEND_URL;
+
+class GuestPreview extends React.Component {
+
+    componentDidMount(){
+        axios.get(`${backendUrl}/api/guests/${this.props.guest.guest_id}`, options).then(res => {
+            this.setState({
+                guest: res.data.guest
+            })
+        })
+    }
+    
     constructor(props){
         super(props);
-        this.state = {};
-
+        this.state = {
+            guest: null,
+        };
     }
-
+    
     render(){
-        console.log(this.props.guest);
+        // tab 0 = upcoming, 1 = incomplete, 2 = complete
+        console.log(this.state.guest);
         return (
             <div>
-                Guest Preview
+                <br></br>
+                <Link to = {`/guests/${this.props.guest.guest_id}`} >
                 <Card>
                     <CardContent>
-                    preview
-                    </CardContent>
+                    {this.state.guest ? (
+                        <div>
+                            <Typography variant = 'h4'>
+                            {this.state.guest.guest_name}
+                            </Typography>
 
+                            <Typography variant = 'overline'>Check-In</Typography>
+                            <Typography variant = 'h6'>{moment(this.state.guest.checkin).format('L')}</Typography>
+                            <Typography variant = 'overline'>Check-Out</Typography>
+                            <Typography variant = 'h6'>{moment(this.state.guest.checkout).format('L')}</Typography>
+                        </div>
+                    ) : null}
+                    </CardContent>
                 </Card>
+                </Link>
+                <br></br>
             </div>
         )
     }
@@ -35,12 +74,15 @@ class Reports extends React.Component {
 const mapStateToProps = state => {
     return {
         // state items
+        tasks: state.propertyReducer.tasks,
+        guests: state.guestReducer.guests
+
     }
 }
 
 export default withRouter(connect(mapStateToProps, {
     // actions
     
-})(Reports))
+})(GuestPreview))
 
 

--- a/src/components/Guests.js
+++ b/src/components/Guests.js
@@ -111,9 +111,11 @@ class Guests extends React.Component {
 					open={this.state.addModal}
 					TransitionComponent={Transition}
 					keepMounted
-					onClose={this.handleModalClose}
+                    onClose={this.handleModalClose}
+                    fullWidth = {false}
+                    maxWidth = {'70%'}
 				>
-					<DialogContent>
+					<DialogContent fullWidth = {false} maxWidth = {'100%'}>
 						<AddGuestForm close={this.handleModalClose} />
 					</DialogContent>
 				</Dialog>

--- a/src/components/Guests.js
+++ b/src/components/Guests.js
@@ -5,7 +5,16 @@ import {connect} from 'react-redux';
 // Router
 import {withRouter} from 'react-router-dom';
 
+import {fetchAllGuests} from '../actions/index';
+
 class Guests extends React.Component {
+
+    componentDidMount(){
+        if(!this.props.guests){
+            this.props.fetchAllGuests();
+        }
+    }
+
     constructor(props){
         super(props);
         this.state = {};
@@ -14,7 +23,11 @@ class Guests extends React.Component {
 
     render(){
         return (
-            <div></div>
+            <div>
+
+
+
+            </div>
         )
     }
 }
@@ -23,12 +36,14 @@ class Guests extends React.Component {
 const mapStateToProps = state => {
     return {
         // state items
+        guests: state.guestReducer.guests,
+        refreshGuests: state.guestReducer.refreshGuests,
     }
 }
 
 export default withRouter(connect(mapStateToProps, {
     // actions
-    
+    fetchAllGuests,
 })(Guests))
 
 

--- a/src/components/Guests.js
+++ b/src/components/Guests.js
@@ -7,6 +7,51 @@ import {withRouter} from 'react-router-dom';
 
 import {fetchAllGuests} from '../actions/index';
 
+import AddGuestForm from './AddGuestForm';
+
+import styled from 'styled-components';
+
+import {withStyles} from '@material-ui/core/styles';
+import Card from '@material-ui/core/Card';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import Button from '@material-ui/core/Button';
+import Typography from '@material-ui/core/Typography';
+
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import Slide from '@material-ui/core/Slide';
+
+// Icons
+import Fab from '@material-ui/core/Fab';
+import AddIcon from '@material-ui/icons/Add';
+
+
+
+const styles = {
+        card: {
+            minWidth: 275,
+        },
+        addIcon: {
+            fontSize: '5rem',
+            cursor: 'pointer'
+        }
+    }
+
+const TopBar = styled.div`
+	width: 100%;
+	display: flex;
+	flex-flow: row nowrap;
+	justify-content: space-between;
+	align-items: center;
+`;
+
+
+
+function Transition(props) {
+	return <Slide direction="up" {...props} />;
+}
+
 class Guests extends React.Component {
 
     componentDidMount(){
@@ -17,13 +62,50 @@ class Guests extends React.Component {
 
     constructor(props){
         super(props);
-        this.state = {};
+        this.state = {
+            addModal: false,
+        };
 
     }
 
+    handleModalOpen = () => {
+		this.setState({
+			addModal: true
+		});
+	};
+
+	handleModalClose = () => {
+		this.setState({
+			addModal: false
+		});
+	};
+
     render(){
+        const {classes} = this.props;
         return (
             <div>
+                <TopBar>
+					<Typography variant="h2">Guests</Typography>{' '}
+					<Fab
+						color="primary"
+						className={classes.addIcon}
+						onClick={this.handleModalOpen}
+					>
+						<AddIcon />
+					</Fab>
+				</TopBar>
+
+                <Dialog
+					open={this.state.addModal}
+					TransitionComponent={Transition}
+					keepMounted
+					onClose={this.handleModalClose}
+				>
+					<DialogContent>
+						<AddGuestForm close={this.handleModalClose} />
+					</DialogContent>
+				</Dialog>
+
 
 
 
@@ -44,6 +126,6 @@ const mapStateToProps = state => {
 export default withRouter(connect(mapStateToProps, {
     // actions
     fetchAllGuests,
-})(Guests))
+}
 
-
+)(withStyles(styles)(Guests)));

--- a/src/components/Guests.js
+++ b/src/components/Guests.js
@@ -5,7 +5,7 @@ import {connect} from 'react-redux';
 // Router
 import {withRouter} from 'react-router-dom';
 
-import {fetchAllGuests} from '../actions/index';
+import {fetchAllGuests, getUserProperties, getCleaners} from '../actions/index';
 
 import AddGuestForm from './AddGuestForm';
 
@@ -59,6 +59,18 @@ class Guests extends React.Component {
             this.props.fetchAllGuests();
         }
     }
+
+
+    componentDidUpdate(prevProps) {
+
+		if (prevProps.refreshProperties !== this.props.refreshProperties) {
+			this.props.getUserProperties();
+		}
+
+		if(prevProps.refreshCleaners !== this.props.refreshCleaners){
+			this.props.getCleaners();
+		}
+	}
 
     constructor(props){
         super(props);
@@ -120,12 +132,16 @@ const mapStateToProps = state => {
         // state items
         guests: state.guestReducer.guests,
         refreshGuests: state.guestReducer.refreshGuests,
+        refreshProperties: state.propertyReducer.refreshProperties,
+        refreshCleaners: state.propertyReducer.refreshCleaners,
     }
 }
 
 export default withRouter(connect(mapStateToProps, {
     // actions
     fetchAllGuests,
+    getUserProperties,
+    getCleaners,
 }
 
 )(withStyles(styles)(Guests)));

--- a/src/components/Guests.js
+++ b/src/components/Guests.js
@@ -116,6 +116,7 @@ class Guests extends React.Component {
 						<AddIcon />
 					</Fab>
 				</TopBar>
+                <br></br>
 
                 <Dialog
 					open={this.state.addModal}
@@ -150,12 +151,12 @@ class Guests extends React.Component {
 
                             </div>
                         ) : null}
-
+{/* 
                         {this.state.tab === 0 && <TabContainer>Upcoming</TabContainer>}
 
                         {this.state.tab === 1 && <TabContainer>Incomplete</TabContainer>}
 
-                        {this.state.tab === 2 && <TabContainer>Complete</TabContainer>}
+                        {this.state.tab === 2 && <TabContainer>Complete</TabContainer>} */}
 
                         </div>
                     

--- a/src/components/Guests.js
+++ b/src/components/Guests.js
@@ -9,13 +9,11 @@ import {fetchAllGuests, getUserProperties, getCleaners} from '../actions/index';
 
 import AddGuestForm from './AddGuestForm';
 
+import GuestPreview from './GuestPreview';
+
 import styled from 'styled-components';
 
 import {withStyles} from '@material-ui/core/styles';
-import Card from '@material-ui/core/Card';
-import CardActions from '@material-ui/core/CardActions';
-import CardContent from '@material-ui/core/CardContent';
-import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 
 import Dialog from '@material-ui/core/Dialog';
@@ -98,8 +96,6 @@ class Guests extends React.Component {
     };
     
     handleTab = value => event => {
-        console.log(event.target);
-        console.log(value);
         this.setState({
             tab: value,
         })
@@ -107,6 +103,7 @@ class Guests extends React.Component {
 
     render(){
         const {classes} = this.props;
+
         return (
             <div>
                 <TopBar>
@@ -138,15 +135,28 @@ class Guests extends React.Component {
 
                     <div>
                         <AppBar position="static">
-                            <Tabs value={this.state.tab}>
+                            <Tabs value={this.state.tab} variant = 'fullWidth'>
                             <Tab label="Upcoming" value = {0} onClick = {this.handleTab(0)} />
                             <Tab label="Incomplete" value = {1} onClick = {this.handleTab(1)} />
                             <Tab label="Complete" value = {2} onClick = {this.handleTab(2)} />
                             </Tabs>
                         </AppBar>
+
+                        {this.props.guests ? (
+                            <div>
+                                {this.props.guests.map(guest => {
+                                    return <GuestPreview guest = {guest} tab = {this.state.tab}></GuestPreview>
+                                })}
+
+                            </div>
+                        ) : null}
+
                         {this.state.tab === 0 && <TabContainer>Upcoming</TabContainer>}
+
                         {this.state.tab === 1 && <TabContainer>Incomplete</TabContainer>}
+
                         {this.state.tab === 2 && <TabContainer>Complete</TabContainer>}
+
                         </div>
                     
                 ): null}

--- a/src/components/Guests.js
+++ b/src/components/Guests.js
@@ -26,6 +26,9 @@ import Slide from '@material-ui/core/Slide';
 import Fab from '@material-ui/core/Fab';
 import AddIcon from '@material-ui/icons/Add';
 
+import AppBar from '@material-ui/core/AppBar';
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
 
 
 const styles = {
@@ -46,7 +49,12 @@ const TopBar = styled.div`
 	align-items: center;
 `;
 
+const TabContainer = styled.div`
 
+    display: flex;
+    flex-flow: column nowrap;
+    border: 2px solid black;
+    `;
 
 function Transition(props) {
 	return <Slide direction="up" {...props} />;
@@ -58,24 +66,21 @@ class Guests extends React.Component {
         if(!this.props.guests){
             this.props.fetchAllGuests();
         }
+
+        if(!this.props.properties){
+            this.props.getUserProperties();
+        }
+
+        if(!this.props.cleaners){
+            this.props.getCleaners();
+        }
     }
-
-
-    componentDidUpdate(prevProps) {
-
-		if (prevProps.refreshProperties !== this.props.refreshProperties) {
-			this.props.getUserProperties();
-		}
-
-		if(prevProps.refreshCleaners !== this.props.refreshCleaners){
-			this.props.getCleaners();
-		}
-	}
 
     constructor(props){
         super(props);
         this.state = {
             addModal: false,
+            tab: 0,
         };
 
     }
@@ -90,7 +95,15 @@ class Guests extends React.Component {
 		this.setState({
 			addModal: false
 		});
-	};
+    };
+    
+    handleTab = value => event => {
+        console.log(event.target);
+        console.log(value);
+        this.setState({
+            tab: value,
+        })
+    }
 
     render(){
         const {classes} = this.props;
@@ -119,6 +132,24 @@ class Guests extends React.Component {
 						<AddGuestForm close={this.handleModalClose} />
 					</DialogContent>
 				</Dialog>
+
+
+                {this.props.guests ? (
+
+                    <div>
+                        <AppBar position="static">
+                            <Tabs value={this.state.tab}>
+                            <Tab label="Upcoming" value = {0} onClick = {this.handleTab(0)} />
+                            <Tab label="Incomplete" value = {1} onClick = {this.handleTab(1)} />
+                            <Tab label="Complete" value = {2} onClick = {this.handleTab(2)} />
+                            </Tabs>
+                        </AppBar>
+                        {this.state.tab === 0 && <TabContainer>Upcoming</TabContainer>}
+                        {this.state.tab === 1 && <TabContainer>Incomplete</TabContainer>}
+                        {this.state.tab === 2 && <TabContainer>Complete</TabContainer>}
+                        </div>
+                    
+                ): null}
 
 
 

--- a/src/components/Guests.js
+++ b/src/components/Guests.js
@@ -74,6 +74,12 @@ class Guests extends React.Component {
         }
     }
 
+    componentDidUpdate(prevProps){
+        if(prevProps.refreshGuests !== this.props.refreshGuests){
+            this.props.fetchAllGuests();
+        }
+    }
+
     constructor(props){
         super(props);
         this.state = {

--- a/src/components/PartnerCard.js
+++ b/src/components/PartnerCard.js
@@ -133,7 +133,7 @@ class PartnerCard extends React.Component {
 						subheader={this.props.partner.address}
 						avatar={
 							<Avatar>
-								<img className={classes.img} src={this.props.partner.img_url} />
+								<img alt = 'partner avatar' className={classes.img} src={this.props.partner.img_url} />
 							</Avatar>
 						}
 						action={

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -49,7 +49,7 @@ class Partners extends React.Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		if(!this.props.properties){
+		if(this.props.refreshProperties !== prevProps.refreshProperties){
 			this.props.getUserProperties();
 		}
 
@@ -59,8 +59,12 @@ class Partners extends React.Component {
 	}
 
 	componentDidMount() {
-		this.props.getUserProperties();
-		this.props.getPartners();
+		if(!this.props.properties){
+			this.props.getUserProperties();
+		}
+		if(!this.props.cleaners){
+			this.props.getPartners();
+		}
 	}
 
 	handleInputChange = event => {
@@ -91,6 +95,7 @@ class Partners extends React.Component {
 		const backendUrl = process.env.backendURL || 'http://localhost:5000';
 		try {
 			const res = await axios.post(`${backendUrl}/api/invites/`, body, options);
+			console.log(res);
 		} catch (err) {
 			console.log(err);
 		}

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -49,8 +49,11 @@ class Partners extends React.Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		if (this.props.refreshCleaners) {
+		if(!this.props.properties){
 			this.props.getUserProperties();
+		}
+
+		if (this.props.refreshCleaners !== prevProps.refreshCleaners) {
 			this.props.getPartners();
 		}
 	}

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -61,6 +61,9 @@ function Transition(props) {
 
 class Properties extends React.Component {
 	componentDidMount() {
+		if(!localStorage.getItem('userInfo')){
+			this.props.checkIfUserExists(localStorage.getItem('role') || localStorage.getItem('accountType'));
+		}
 		this.props.getUserProperties();
 	}
 

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -56,7 +56,7 @@ const styles = {
 };
 
 function Transition(props) {
-	return <Slide direction="down" {...props} />;
+	return <Slide direction="up" {...props} />;
 }
 
 class Properties extends React.Component {
@@ -77,22 +77,9 @@ class Properties extends React.Component {
 	constructor(props) {
 		super(props);
 		this.state = {
-			anchorEl: null,
 			addModal: false
 		};
 	}
-
-	handleMenuClick = event => {
-		this.setState({
-			anchorEl: event.currentTarget
-		});
-	};
-
-	handleClose = () => {
-		this.setState({
-			anchorEl: null
-		});
-	};
 
 	handleModalOpen = () => {
 		this.setState({

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -15,7 +15,7 @@ import NativeSelect from '@material-ui/core/NativeSelect';
 import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core';
 
-import { withRouter } from 'react-router-dom';
+import { withRouter, Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 import { changeCleaner } from '../actions/propertyActions';
@@ -86,10 +86,12 @@ class PropertyPreview extends React.Component {
 		return (
 			<div>
 				<Card className={classes.card} key={this.props.property.id}>
+					<Link to = {`/properties/${this.props.property.property_id}`}>
 					<CardHeader
 						title={this.props.property.property_name}
 						subheader={this.props.property.address}
 					/>
+					</Link>
 
 					<CardContent>
 						<Typography variant="overline">Select Cleaner</Typography>

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -22,7 +22,7 @@ import { changeCleaner } from '../actions/propertyActions';
 
 const styles = {
 	card: {
-		maxWidth: 600,
+		maxWidth: '100%',
 		margin: '20px auto'
 	},
 	media: {
@@ -76,8 +76,6 @@ class PropertyPreview extends React.Component {
 			cleaner: event.target.value
 		});
 
-		console.log(event.target.value.id);
-
 		this.props.changeCleaner(this.props.property.id, event.target.value.id);
 	};
 
@@ -94,11 +92,10 @@ class PropertyPreview extends React.Component {
 					</Link>
 
 					<CardContent>
-						<Typography variant="overline">Select Cleaner</Typography>
 
 						<FormControl className={classes.formControl}>
 							<InputLabel shrink htmlFor="cleaner-native-label-placeholder">
-								Assigned Cleaner
+								Select Default Cleaner
 							</InputLabel>
 							{this.state.cleaner ? (
 								<NativeSelect

--- a/src/components/__App/App.js
+++ b/src/components/__App/App.js
@@ -6,6 +6,9 @@ import styled from 'styled-components';
 
 import { checkIfUserExists } from '../../actions/index';
 
+import MomentUtils from '@date-io/moment';
+import { MuiPickersUtilsProvider } from '@material-ui/pickers';
+
 // Components
 import {
 	Home,
@@ -42,6 +45,7 @@ class App extends Component {
 	render() {
 		return (
 			<div>
+				<MuiPickersUtilsProvider utils={MomentUtils}>
 				<CssBaseline />
 				<Navigation />
 				{/* Declare Routes */}
@@ -60,6 +64,7 @@ class App extends Component {
 						<Route path="/invite/:invite_code" component={Invite} />
 					</Switch>
 				</ComponentContainer>
+				</MuiPickersUtilsProvider>
 			</div>
 		);
 	}

--- a/src/components/__App/App.js
+++ b/src/components/__App/App.js
@@ -37,7 +37,7 @@ const ComponentContainer = styled.div`
 
 class App extends Component {
 	componentDidMount() {
-		if (!this.props.userInfo) {
+		if (!this.props.userInfo || !localStorage.getItem('userInfo')) {
 			this.props.checkIfUserExists(localStorage.getItem('accountType') || localStorage.getItem('role'));
 		}
 	}

--- a/src/components/__App/App.js
+++ b/src/components/__App/App.js
@@ -37,7 +37,7 @@ const ComponentContainer = styled.div`
 
 class App extends Component {
 	componentDidMount() {
-		if (!this.props.userInfo || !localStorage.getItem('userInfo')) {
+		if (localStorage.getItem('isLoggedIn') && !localStorage.getItem('userInfo')) {
 			this.props.checkIfUserExists(localStorage.getItem('accountType') || localStorage.getItem('role'));
 		}
 	}

--- a/src/reducers/guestReducer.js
+++ b/src/reducers/guestReducer.js
@@ -4,11 +4,13 @@ import {
 	GET_GUEST_ERROR,
 	UPDATING_GUEST_TASK,
 	UPDATED_GUEST_TASK,
-	UPDATE_GUEST_TASK_ERROR
+	UPDATE_GUEST_TASK_ERROR,
+	GUESTS_FETCHED,
 } from '../actions';
 
 const initialState = {
-	guest: {}
+	guest: {},
+	refreshGuests: false,
 };
 
 const guestReducer = (state = initialState, action) => {
@@ -26,6 +28,15 @@ const guestReducer = (state = initialState, action) => {
 				gettingGuest: undefined,
 				getGuestError: action.payload
 			};
+
+		case GUESTS_FETCHED:
+			return {
+				...state,
+				guests: action.payload,
+				refreshGuests: false,
+			}
+
+		
 
 		// updateGuestTask
 		case UPDATING_GUEST_TASK:

--- a/src/reducers/guestReducer.js
+++ b/src/reducers/guestReducer.js
@@ -6,6 +6,7 @@ import {
 	UPDATED_GUEST_TASK,
 	UPDATE_GUEST_TASK_ERROR,
 	GUESTS_FETCHED,
+	GUEST_ADDED,
 } from '../actions';
 
 const initialState = {
@@ -36,6 +37,11 @@ const guestReducer = (state = initialState, action) => {
 				refreshGuests: false,
 			}
 
+		case GUEST_ADDED:
+			return {
+				...state,
+				refreshGuests: true,
+			}
 		
 
 		// updateGuestTask

--- a/src/reducers/propertyReducer.js
+++ b/src/reducers/propertyReducer.js
@@ -25,12 +25,13 @@ const initialState = {
 	refreshProperties: false,
 	cleaners: null,
 	refreshCleaners: false,
-	partners: null
+	partners: null,
+	tasks: null,
 };
 
 const propertyReducer = (state = initialState, action) => {
 	switch (action.type) {
-		
+
 		case USER_CHECKED:
 			return {
 				...state,

--- a/src/reducers/propertyReducer.js
+++ b/src/reducers/propertyReducer.js
@@ -15,7 +15,8 @@ import {
 	ADD_TASK_ERROR,
 	DELETING_TASK,
 	DELETED_TASK,
-	DELETE_TASK_ERROR
+	DELETE_TASK_ERROR,
+	USER_CHECKED,
 } from '../actions';
 
 const initialState = {
@@ -29,6 +30,12 @@ const initialState = {
 
 const propertyReducer = (state = initialState, action) => {
 	switch (action.type) {
+		case USER_CHECKED:
+			return {
+				...state,
+				refreshProperties: true,
+			}
+
 		case GETTING_PROPERTY:
 			return { ...state, gettingProperty: true };
 

--- a/src/reducers/propertyReducer.js
+++ b/src/reducers/propertyReducer.js
@@ -30,6 +30,7 @@ const initialState = {
 
 const propertyReducer = (state = initialState, action) => {
 	switch (action.type) {
+		
 		case USER_CHECKED:
 			return {
 				...state,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8505,11 +8505,6 @@ property-information@^5.0.0, property-information@^5.0.1:
   dependencies:
     xtend "^4.0.1"
 
-proptypes@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proptypes/-/proptypes-1.1.0.tgz#78b3828a5aa6bb1308939e0de3c6044dfd4bd239"
-  integrity sha1-eLOCilqmuxMIk54N48YETf1L0jk=
-
 proxy-addr@~2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.5.tgz#34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34"

--- a/yarn.lock
+++ b/yarn.lock
@@ -910,6 +910,16 @@
   resolved "https://registry.yarnpkg.com/@csstools/normalize.css/-/normalize.css-9.0.1.tgz#c27b391d8457d1e893f1eddeaf5e5412d12ffbb5"
   integrity sha512-6It2EVfGskxZCQhuykrfnALg7oVeiI6KclWSmGDqB0AiInVrTGB9Jp9i4/Ad21u9Jde/voVQz6eFX/eSg/UsPA==
 
+"@date-io/core@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@date-io/core/-/core-1.3.6.tgz#5c518cee6fa011e754293aebc6f1192360061797"
+  integrity sha512-cihiu8YaTHh7IqrzekbZcA7dh+7uhViHgWyxcKAO2cg1DYGYC5J7z4/rnGGL7swrK5xFVLIeyoxJ+sacziIRKg==
+
+"@date-io/moment@^1.3.6":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@date-io/moment/-/moment-1.3.6.tgz#ee6d911c400e66c0bfe6cd782be36834f529de03"
+  integrity sha512-aaWDAPaiwmya/W8ERd19BohO8mgNwPP/l/nTwcG7V+WZKQjDotOfcIHJaDSLKbDsA5WDP6kxDrbXE15Jztvu/g==
+
 "@emotion/cache@^10.0.9":
   version "10.0.9"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.9.tgz#e0c7b7a289f7530edcfad4dcf3858bd2e5700a6f"
@@ -1197,6 +1207,18 @@
   dependencies:
     "@babel/runtime" "^7.2.0"
 
+"@material-ui/pickers@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@material-ui/pickers/-/pickers-3.0.0.tgz#cd99933e5701fa5aeea1862418b43fc399398e15"
+  integrity sha512-tjnKWHudaZ089Gsxvio/8DxDVUmPIx/RRi1O66haAGGJmahoI9ICDU8lwpoU828nY7f3mQN7lSrca9bdAdrLoA==
+  dependencies:
+    "@types/styled-jsx" "^2.2.8"
+    clsx "^1.0.2"
+    react-event-listener "^0.6.6"
+    react-transition-group "^4.0.0"
+    rifm "^0.7.0"
+    tslib "^1.9.3"
+
 "@material-ui/styles@^4.0.1":
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.0.1.tgz#67e880d490f010c9f2956c572b07d218bfa255d7"
@@ -1454,6 +1476,13 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/styled-jsx@^2.2.8":
+  version "2.2.8"
+  resolved "https://registry.yarnpkg.com/@types/styled-jsx/-/styled-jsx-2.2.8.tgz#b50d13d8a3c34036282d65194554cf186bab7234"
+  integrity sha512-Yjye9VwMdYeXfS71ihueWRSxrruuXTwKCbzue4+5b2rjnQ//AtyM7myZ1BEhNhBQ/nL/RE7bdToUoLln2miKvg==
+  dependencies:
+    "@types/react" "*"
 
 "@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2":
   version "2.0.3"
@@ -6879,6 +6908,11 @@ mkdirp@0.5.1, mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@
   dependencies:
     minimist "0.0.8"
 
+moment@^2.24.0:
+  version "2.24.0"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
+  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -8471,6 +8505,11 @@ property-information@^5.0.0, property-information@^5.0.1:
   dependencies:
     xtend "^4.0.1"
 
+proptypes@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/proptypes/-/proptypes-1.1.0.tgz#78b3828a5aa6bb1308939e0de3c6044dfd4bd239"
+  integrity sha1-eLOCilqmuxMIk54N48YETf1L0jk=
+
 proxy-addr@~2.0.5:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/proxy-addr/-/proxy-addr-2.0.5.tgz#34cbd64a2d81f4b1fd21e76f9f06c8a45299ee34"
@@ -9283,6 +9322,13 @@ rgba-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/rgba-regex/-/rgba-regex-1.0.0.tgz#43374e2e2ca0968b0ef1523460b7d730ff22eeb3"
   integrity sha1-QzdOLiyglosO8VI0YLfXMP8i7rM=
+
+rifm@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/rifm/-/rifm-0.7.0.tgz#debe951a9c83549ca6b33e5919f716044c2230be"
+  integrity sha512-DSOJTWHD67860I5ojetXdEQRIBvF6YcpNe53j0vn1vp9EUb9N80EiZTxgP+FkDKorWC8PZw052kTF4C1GOivCQ==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
 
 rimraf@2.6.3, rimraf@^2.2.8, rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.2, rimraf@^2.6.3:
   version "2.6.3"
@@ -10326,7 +10372,7 @@ ts-pnp@1.1.2, ts-pnp@^1.0.0:
   resolved "https://registry.yarnpkg.com/ts-pnp/-/ts-pnp-1.1.2.tgz#be8e4bfce5d00f0f58e0666a82260c34a57af552"
   integrity sha512-f5Knjh7XCyRIzoC/z1Su1yLLRrPrFCgtUAh/9fCSP6NKbATwpOL1+idQVXQokK9GRFURn/jYPGPfegIctwunoA==
 
-tslib@^1.8.1, tslib@^1.9.0:
+tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
@@ -10379,6 +10425,11 @@ typedarray@^0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
+typescript@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
+  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
 
 ua-parser-js@^0.7.18, ua-parser-js@^0.7.9:
   version "0.7.19"


### PR DESCRIPTION
Alrighty, so this adds functionality to the guests page for viewing and adding guest reservations using material-ui date pickers. It still needs update/delete actions, those are forthcoming.

Guests list should auto-regenerate after successfully adding a guest.

Currently, there are tabs for 'upcoming, incomplete, complete' however these filters are not functional yet. Max's latest PR has some improvements for task aggregation I believe, so once that's merged the filtration should be easier to perform without having to do too much logic on the client-side.

I've also implemented a helper function `setHeaders()` inside of the actions files, this should help DRY up some of the code a bit.

moment.js is added to parse date-time values for better UX, and I added some peer dependencies that were unmet and throwing warnings during yarn install.

I also managed to fix the infinite loop on the partners page that was a result of insufficient comparisons during the component lifecycle methods.

**This update will require a `yarn install` due to new dependencies.**

