### PR TITLE
Fix/partnersretrieval

### DIFF
--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -51,20 +51,16 @@ class Partners extends React.Component {
 	componentDidUpdate(prevProps) {
 		if(this.props.refreshProperties !== prevProps.refreshProperties){
 			this.props.getUserProperties();
-		}
-
-		if (this.props.refreshCleaners !== prevProps.refreshCleaners) {
 			this.props.getPartners();
 		}
 	}
 
 	componentDidMount() {
-		if(!this.props.properties){
+		if(!this.props.partners){
 			this.props.getUserProperties();
-		}
-		if(!this.props.cleaners){
 			this.props.getPartners();
-		}
+	}
+		
 	}
 
 	handleInputChange = event => {
@@ -141,7 +137,8 @@ const mapStateToProps = state => {
 		// state items
 		properties: state.propertyReducer.properties,
 		cleaners: state.propertyReducer.partners,
-		refreshCleaners: state.propertyReducer.refreshCleaners
+		refreshCleaners: state.propertyReducer.refreshCleaners,
+		refreshProperties: state.propertyReducer.refreshProperties
 	};
 };
 

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -71,12 +71,13 @@ class PropertyPreview extends React.Component {
 		};
 	}
 
-	handleSelect = event => {
+	handleSelect =  event => {
+		const selectedCleaner = this.props.cleaners.filter(cleaner => cleaner.user_id === event.target.value)
 		this.setState({
-			cleaner: event.target.value
+			cleaner: selectedCleaner
 		});
 
-		this.props.changeCleaner(this.props.property.id, event.target.value.id);
+		this.props.changeCleaner(this.props.property.property_id, event.target.value);
 	};
 
 	render() {
@@ -111,7 +112,7 @@ class PropertyPreview extends React.Component {
 									{this.props.cleaners
 										? this.props.cleaners.map(cleaner => {
 												return (
-													<option value={cleaner} key={cleaner.user_id}>
+													<option value={cleaner.user_id} key={cleaner.user_id}>
 														{cleaner.user_name}
 													</option>
 												);

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -35,10 +35,14 @@ const styles = {
 };
 
 class PropertyPreview extends React.Component {
+
+	componentDidMount(){
+
+	}
+
 	componentDidUpdate(oldProps) {
 		if (
-			this.props.cleaners !== oldProps.cleaners ||
-			this.props.refreshCleaners
+			this.props.cleaners !== oldProps.cleaners 
 		) {
 			let defaultCleaner;
 
@@ -49,13 +53,13 @@ class PropertyPreview extends React.Component {
 					}
 				});
 			} else {
-				defaultCleaner = this.props.cleaners.map(cleaner => {
+				this.props.cleaners.map(cleaner => {	
 					if (cleaner.user_id === this.props.property.cleaner_id) {
-						return cleaner;
+						defaultCleaner = cleaner;
 					}
 				});
 			}
-
+			console.log(defaultCleaner);
 			this.setState({
 				cleaner: defaultCleaner
 			});
@@ -96,7 +100,7 @@ class PropertyPreview extends React.Component {
 
 						<FormControl className={classes.formControl}>
 							<InputLabel shrink htmlFor="cleaner-native-label-placeholder">
-								Select Default Cleaner
+								Default Cleaner
 							</InputLabel>
 							{this.state.cleaner ? (
 								<NativeSelect
@@ -105,12 +109,15 @@ class PropertyPreview extends React.Component {
 									input={
 										<Input
 											name="cleaner"
-											id="cleaner-native-label-placeolder"
+											id="cleaner-native-label-placeholder"
 										/>
 									}
 								>
+									<option value="">{this.state.cleaner.user_name}</option>
 									{this.props.cleaners
 										? this.props.cleaners.map(cleaner => {
+												if(cleaner.user_id === this.state.cleaner.user_id)
+													return null;
 												return (
 													<option value={cleaner.user_id} key={cleaner.user_id}>
 														{cleaner.user_name}
@@ -131,7 +138,8 @@ class PropertyPreview extends React.Component {
 const mapStateToProps = state => {
 	return {
 		// state items
-		cleaners: state.propertyReducer.cleaners
+		cleaners: state.propertyReducer.cleaners,
+		refreshCleaners: state.propertyReducer.refreshCleaners
 	};
 };
 

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -36,10 +36,6 @@ const styles = {
 
 class PropertyPreview extends React.Component {
 
-	componentDidMount(){
-
-	}
-
 	componentDidUpdate(oldProps) {
 		if (
 			this.props.cleaners !== oldProps.cleaners 
@@ -59,7 +55,7 @@ class PropertyPreview extends React.Component {
 					}
 				});
 			}
-			console.log(defaultCleaner);
+
 			this.setState({
 				cleaner: defaultCleaner
 			});
@@ -76,7 +72,9 @@ class PropertyPreview extends React.Component {
 	}
 
 	handleSelect =  event => {
-		const selectedCleaner = this.props.cleaners.filter(cleaner => cleaner.user_id === event.target.value)
+		const selectedCleaner = this.props.cleaners.filter(
+			cleaner => cleaner.user_id === event.target.value
+		);
 		this.setState({
 			cleaner: selectedCleaner
 		});

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -35,6 +35,27 @@ const styles = {
 };
 
 class PropertyPreview extends React.Component {
+	componentDidMount() {
+		if(this.props.cleaners){
+		let defaultCleaner;
+			if (this.props.property.cleaner_id === null) {
+				defaultCleaner = this.props.cleaners.map(cleaner => {
+					if (cleaner.user_id === this.props.property.manager_id) {
+						return cleaner;
+					}
+				});
+			} else {
+				this.props.cleaners.map(cleaner => {	
+					if (cleaner.user_id === this.props.property.cleaner_id) {
+						defaultCleaner = cleaner;
+					}
+				});
+			}
+			this.setState({
+				cleaner: defaultCleaner
+			});
+		}
+	}
 
 	componentDidUpdate(oldProps) {
 		if (
@@ -55,7 +76,6 @@ class PropertyPreview extends React.Component {
 					}
 				});
 			}
-
 			this.setState({
 				cleaner: defaultCleaner
 			});

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -51,6 +51,7 @@ class PropertyPreview extends React.Component {
 					}
 				});
 			}
+
 			this.setState({
 				cleaner: defaultCleaner
 			});
@@ -76,6 +77,7 @@ class PropertyPreview extends React.Component {
 					}
 				});
 			}
+
 			this.setState({
 				cleaner: defaultCleaner
 			});

--- a/src/reducers/propertyReducer.js
+++ b/src/reducers/propertyReducer.js
@@ -61,7 +61,7 @@ const propertyReducer = (state = initialState, action) => {
 			return { ...state, cleaners: action.payload, refreshCleaners: false };
 
 		case CLEANER_UPDATED:
-			return { ...state, refreshCleaners: true };
+			return { ...state, refreshCleaners: true, refreshProperties: true };
 		
 		case FETCHING_PARTNERS:
 			return {...state, refreshCleaners: false};


### PR DESCRIPTION
Made several polishing fixes to the properties and partners page:
- Changing default cleaner on properties page now sends the proper user id to be changed for the property
- Added refreshCleaners state variable to Partners page and use it for proper properties rerendering
- Properties page now has the right default cleaner as first option on the input list