### PR TITLE
Partnerviews/properties

### DIFF
--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -33,6 +33,7 @@ export const checkIfUserExists = (role) => {
 
         checkUrl.then(res => {
             localStorage.setItem('userInfo', res.data.userInfo);
+            localStorage.setItem('role', res.data.user.role)
             // localStorage.setItem('userId', res.data.profile.id);
             dispatch({type: USER_CHECKED, payload: res.data});
         }).catch(err => {

--- a/src/components/AddPropertyForm.js
+++ b/src/components/AddPropertyForm.js
@@ -19,7 +19,7 @@ const styles = {
 		display: 'flex',
 		flexFlow: 'column nowrap',
 		padding: '5%',
-		height: '50vh'
+		height: '80vh'
 	},
 	formField: {
 		margin: '10px 0px'
@@ -91,6 +91,20 @@ class AddPropertyForm extends React.Component {
 						label="Address"
 						value={this.state.address}
 						onChange={this.handleInput('address')}
+					/>
+					<TextField
+						className={classes.formField}
+						id="standard-dense"
+						label="Guest Guide URL"
+						value={this.state.guest_guide}
+						onChange={this.handleInput('guest_guide')}
+					/>
+					<TextField
+						className={classes.formField}
+						id="standard-dense"
+						label="Assistant Guide URL"
+						value={this.state.assistant_guide}
+						onChange={this.handleInput('assistant_guide')}
 					/>
 					<Button
 						className={classes.formButton}

--- a/src/components/Invite.js
+++ b/src/components/Invite.js
@@ -33,9 +33,10 @@ class Invite extends Component {
 	}
 
 	render() {
+		const loggedIn = localStorage.getItem('jwt');
 		return (
 			<div>
-				{this.props.userInfo ? (
+				{loggedIn ? (
 					<div>
 						{this.state.successful ? (
 							<Typography variant="h6">

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -102,7 +102,7 @@ class Partners extends React.Component {
 			cleaner_email: this.state.email
 		};
 
-		const backendUrl = process.env.backendURL || 'http://localhost:5000';
+		const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:5000';
 		try {
 			const res = await axios.post(`${backendUrl}/api/invites/`, body, options);
 			console.log(res);

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -109,6 +109,8 @@ class Partners extends React.Component {
 		} catch (err) {
 			console.log(err);
 		}
+
+		this.setState({email: ''});
 	};
 
 	render() {

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -67,7 +67,9 @@ class Properties extends React.Component {
 		} else if(!localStorage.getItem('userInfo')){
 			this.props.checkIfUserExists(localStorage.getItem('role') || localStorage.getItem('accountType'));
 		}
+
 		this.props.getUserProperties();
+		this.props.getCleaners();
 	}
 
 	componentDidUpdate(prevProps) {
@@ -75,7 +77,7 @@ class Properties extends React.Component {
 			this.props.getUserProperties();
 		}
 
-		if(prevProps.refreshCleaners !== this.props.refreshCleaners){
+		if(prevProps.refreshCleaners !== this.props.refreshCleaners && localStorage.getItem('role') === 'manager'){
 			this.props.getCleaners();
 		}
 	}
@@ -104,6 +106,19 @@ class Properties extends React.Component {
 		// const open = Boolean(anchorEl);
 		const { classes } = this.props;
 		const role = localStorage.getItem('role');
+		const properties = this.props.properties;
+		let defaultproperties = [];
+		let availableproperties = [];
+		if (role !== 'manager' && this.props.properties && this.props.cleaners){
+			properties.forEach(property => {
+				if (property.cleaner_id === this.props.cleaners[0].user_id)
+					defaultproperties.push(property);
+				if (property.available === this.props.cleaners[0].user_id)
+					availableproperties.push(property);
+			});
+
+			console.log(properties)
+		}
 
 		if(role === 'manager')
 		return (
@@ -144,24 +159,37 @@ class Properties extends React.Component {
 			</div>
 		);
 		else
-
 		return (<div>
 			<TopBar>
 					<Typography variant="h2">Properties</Typography>{' '}
 				</TopBar>
-				
-				{this.props.properties ? (
-					this.props.properties.map(property => {
+				<Typography variant="h5"> Your Default Properties </Typography>
+					{defaultproperties ? (
+					defaultproperties.map(property => {
 						return (
 							<PropertyPreview property={property} key={property.property_id} />
 						);
 					})
 				) : (
 					<Typography variant="overline">
-						No properties have been added yet.
+						You have not been assigned as the default partner for any properties.
+					</Typography>
+				)}
+
+				<Typography variant="h5">Properties You're Available For </Typography>
+					{availableproperties ? (
+					availableproperties.map(property => {
+						return (
+							<PropertyPreview property={property} key={property.property_id} />
+						);
+					})
+				) : (
+					<Typography variant="overline">
+						You have not been assigned as the default partner for any properties.
 					</Typography>
 				)}
 		</div>);
+		
 	}
 }
 

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -148,26 +148,8 @@ class Properties extends React.Component {
 		return (<div>
 			<TopBar>
 					<Typography variant="h2">Properties</Typography>{' '}
-					<Fab
-						color="primary"
-						className={classes.addIcon}
-						onClick={this.handleModalOpen}
-					>
-						<AddIcon />
-					</Fab>
 				</TopBar>
-
-				<Dialog
-					open={this.state.addModal}
-					TransitionComponent={Transition}
-					keepMounted
-					onClose={this.handleModalClose}
-				>
-					<DialogContent>
-						<AddPropertyForm close={this.handleModalClose} />
-					</DialogContent>
-				</Dialog>
-
+				
 				{this.props.properties ? (
 					this.props.properties.map(property => {
 						return (

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -103,7 +103,9 @@ class Properties extends React.Component {
 		// const { anchorEl } = this.state;
 		// const open = Boolean(anchorEl);
 		const { classes } = this.props;
+		const role = localStorage.getItem('role');
 
+		if(role === 'manager')
 		return (
 			<div>
 				<TopBar>
@@ -141,6 +143,43 @@ class Properties extends React.Component {
 				)}
 			</div>
 		);
+		else
+
+		return (<div>
+			<TopBar>
+					<Typography variant="h2">Properties</Typography>{' '}
+					<Fab
+						color="primary"
+						className={classes.addIcon}
+						onClick={this.handleModalOpen}
+					>
+						<AddIcon />
+					</Fab>
+				</TopBar>
+
+				<Dialog
+					open={this.state.addModal}
+					TransitionComponent={Transition}
+					keepMounted
+					onClose={this.handleModalClose}
+				>
+					<DialogContent>
+						<AddPropertyForm close={this.handleModalClose} />
+					</DialogContent>
+				</Dialog>
+
+				{this.props.properties ? (
+					this.props.properties.map(property => {
+						return (
+							<PropertyPreview property={property} key={property.property_id} />
+						);
+					})
+				) : (
+					<Typography variant="overline">
+						No properties have been added yet.
+					</Typography>
+				)}
+		</div>);
 	}
 }
 
@@ -151,7 +190,8 @@ const mapStateToProps = state => {
 		refreshProperties: state.propertyReducer.refreshProperties,
 		cleaners: state.propertyReducer.cleaners,
 		userInfo: state.authReducer.userInfo,
-		refreshCleaners: state.propertyReducer.refreshCleaners
+		refreshCleaners: state.propertyReducer.refreshCleaners,
+		user: state.authReducer.currentUser
 	};
 };
 

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -120,9 +120,7 @@ class PropertyPreview extends React.Component {
 							<InputLabel shrink htmlFor="cleaner-native-label-placeholder">
 								Default Cleaner
 							</InputLabel>
-							{this.state.cleaner ? (
 								<NativeSelect
-									value={this.state.cleaner.user_name} // placholder == assigned cleaner's name
 									onChange={this.handleSelect}
 									input={
 										<Input
@@ -131,10 +129,10 @@ class PropertyPreview extends React.Component {
 										/>
 									}
 								>
-									<option value="">{this.state.cleaner.user_name}</option>
+									<option value="">{this.state.cleaner ? this.state.cleaner.user_name : "Unassigned"}</option>
 									{this.props.cleaners
 										? this.props.cleaners.map(cleaner => {
-												if (cleaner.user_id === this.state.cleaner.user_id)
+												if (this.state.cleaner && cleaner.user_id === this.state.cleaner.user_id)
 													return null;
 												return (
 													<option value={cleaner.user_id} key={cleaner.user_id}>
@@ -144,7 +142,6 @@ class PropertyPreview extends React.Component {
 										  })
 										: null}
 								</NativeSelect>
-							) : null}
 						</FormControl>
 					</CardContent>
 				</Card>

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -102,6 +102,9 @@ class PropertyPreview extends React.Component {
 
 	render() {
 		const { classes } = this.props;
+		const role = localStorage.getItem('role')
+
+		if(role === 'manager')
 		return (
 			<div>
 				<Card className={classes.card} key={this.props.property.id}>
@@ -146,6 +149,21 @@ class PropertyPreview extends React.Component {
 					</CardContent>
 				</Card>
 			</div>
+		);
+
+		else
+		return (
+			<Card className={classes.card} key={this.props.property.id}>
+					<Link to={`/properties/${this.props.property.property_id}`}>
+						<CardHeader
+							title={this.props.property.property_name}
+							subheader={this.props.property.address}
+						/>
+					</Link>
+
+					<CardContent/>
+				</Card>
+
 		);
 	}
 }


### PR DESCRIPTION
- Added role to be saved in local storage for view parsing and thus properties view is now rendered based on the role cookie a user has (Aware that Max's recent pull request contains similar code, I will push his changes and delete mine upon merge)
- Changed invite page to render depending on the existence of a token rather than user props
- Removed ability to change cleaners from assistant view of properties page
- Added guest and assistant guide inputs to the add property form
- Organized the properties an assistant receives from the server into default and available properties
- Mailgun URL was changed to reflect proper env variable usage
- Changed how default cleaners are being rendered so that if a property has no assigned partner it will display as "Unassigned". Making yourself the default cleaner is still possible.