### PR TITLE
Invitation Flow and Modules

### DIFF
--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -6,6 +6,9 @@ export const USER_CHECKED = 'USER_CHECKED';
 export const UPDATING_USER = 'UPDATING_USER';
 export const USER_UPDATED = 'USER_UPDATED';
 
+export const FETCHING_INVITE = 'FETCHING_INVITE';
+export const INVITE_FETCHED = 'INVITE_FETCHED';
+
 export const SET_USER = 'SET_USER';
 
 const backendUrl = process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`;
@@ -112,3 +115,21 @@ export const setUser = user => {
 		dispatch({ type: SET_USER, payload: user });
 	};
 };
+
+export const checkInvite = inviteCode => {
+
+	const endpoint = axios.get(`${backendUrl}/api/invites/info/${inviteCode}`);
+
+	return dispatch => {
+		dispatch({type: FETCHING_INVITE});
+
+		endpoint.then(res => {
+			console.log('invite fetch', res.data);
+			dispatch({type: INVITE_FETCHED, payload: res.data.inviteInfo});
+		}).catch(err => {
+			console.log(err);
+			dispatch({type: ERROR})
+		})
+	}
+	
+}

--- a/src/actions/authActions.js
+++ b/src/actions/authActions.js
@@ -48,6 +48,35 @@ export const checkIfUserExists = role => {
 	};
 };
 
+export const inviteLogin = (role, inviteCode) => {
+	const token = localStorage.getItem('jwt');
+
+	const options = {
+		headers: {
+			Authorization: `Bearer ${token}`,
+		},
+	};
+
+	const body = {
+		role: role,
+	};
+
+	const endpoint = axios.post(`${backendUrl}/api/users/login/${inviteCode}`, body, options);
+
+	return dispatch => {
+		dispatch({type: CHECKING_USER});
+
+		endpoint.then(res => {
+			console.log('invite login res', res.data);
+
+			dispatch({type: USER_CHECKED, payload: res.data})
+		}).catch(err => {
+			console.log(err);
+			dispatch({type: ERROR})
+		})
+	}
+}
+
 export const updateUserProfile = (user_id, changes) => {
 	let token = localStorage.getItem('jwt');
 	let userInfo = localStorage.getItem('userInfo');

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -2,3 +2,4 @@ export * from './authActions';
 export * from './propertyActions';
 export * from './guestActions';
 export * from './reportsActions';
+export * from './partnerActions';

--- a/src/actions/partnerActions.js
+++ b/src/actions/partnerActions.js
@@ -1,0 +1,45 @@
+import axios from 'axios';
+
+export const SENDING_INVITE = 'SENDING_INVITE';
+export const INVITE_SENT = 'INVITE_SENT';
+export const ERROR = 'ERROR';
+
+
+const backendUrl = process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`;
+
+function setHeaders(){
+	const token = localStorage.getItem('jwt');
+	const userInfo = localStorage.getItem('userInfo');
+	
+	const options = {
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'user-info': userInfo
+		}
+	};
+
+	return options;
+}
+
+export const sendInvite = email => {
+    let options = setHeaders();
+
+    let body = {
+        cleaner_email: email,
+    }
+
+    const endpoint = axios.post(`${backendUrl}/api/invites`, body, options);
+
+    return dispatch => {
+        dispatch({type: SENDING_INVITE})
+
+        endpoint.then(res => {
+            console.log('send invite res', res.data);
+
+            dispatch({type: INVITE_SENT})
+        }).catch(err => {
+            console.log(err);
+            dispatch({type: ERROR})
+        })
+    }
+};

--- a/src/actions/partnerActions.js
+++ b/src/actions/partnerActions.js
@@ -37,8 +37,6 @@ export const sendInvite = email => {
         dispatch({type: SENDING_INVITE})
 
         endpoint.then(res => {
-            console.log('send invite res', res.data);
-
             dispatch({type: INVITE_SENT})
         }).catch(err => {
             console.log(err);
@@ -56,8 +54,12 @@ export const getAllInvites = () => {
         dispatch({type: FETCHING_INVITES});
 
         endpoint.then(res => {
-            console.log('all invites', res.data.invites);
-            dispatch({type: INVITES_FETCHED, payload: res.data.invites});
+            if(res.data.invites.length === 0){
+                dispatch({type: INVITES_FETCHED, payload: null});
+            } else {
+                dispatch({type: INVITES_FETCHED, payload: res.data.invites});
+            }
+            
         }).catch(err => {
             console.log(err);
             dispatch({type: ERROR})

--- a/src/actions/partnerActions.js
+++ b/src/actions/partnerActions.js
@@ -2,8 +2,11 @@ import axios from 'axios';
 
 export const SENDING_INVITE = 'SENDING_INVITE';
 export const INVITE_SENT = 'INVITE_SENT';
-export const ERROR = 'ERROR';
 
+export const FETCHING_INVITES = 'FETCHING_INVITES';
+export const INVITES_FETCHED = 'INVITES_FETCHED';
+
+export const ERROR = 'ERROR';
 
 const backendUrl = process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`;
 
@@ -43,3 +46,21 @@ export const sendInvite = email => {
         })
     }
 };
+
+export const getAllInvites = () => {
+    let options = setHeaders();
+
+    const endpoint = axios.get(`${backendUrl}/api/invites/all`, options);
+
+    return dispatch => {
+        dispatch({type: FETCHING_INVITES});
+
+        endpoint.then(res => {
+            console.log('all invites', res.data.invites);
+            dispatch({type: INVITES_FETCHED, payload: res.data.invites});
+        }).catch(err => {
+            console.log(err);
+            dispatch({type: ERROR})
+        })
+    }
+}

--- a/src/actions/propertyActions.js
+++ b/src/actions/propertyActions.js
@@ -85,12 +85,7 @@ export const getUserProperties = () => {
 
 		fetchUrl
 			.then(res => {
-				// handle an empty array and return null if no properties found
-				if(res.data.properties.length === 0){
-					dispatch({ type: PROPERTIES_FETCHED, payload: null });
-				} else {
-					dispatch({ type: PROPERTIES_FETCHED, payload: res.data.properties });
-				}
+				dispatch({ type: PROPERTIES_FETCHED, payload: res.data.properties });
 			})
 			.catch(err => {
 				console.log(err);

--- a/src/actions/propertyActions.js
+++ b/src/actions/propertyActions.js
@@ -85,7 +85,11 @@ export const getUserProperties = () => {
 
 		fetchUrl
 			.then(res => {
-				dispatch({ type: PROPERTIES_FETCHED, payload: res.data.properties });
+				if(res.data.properties.length === 0){
+					dispatch({ type: PROPERTIES_FETCHED, payload: null });
+				} else {
+					dispatch({ type: PROPERTIES_FETCHED, payload: res.data.properties });
+				}
 			})
 			.catch(err => {
 				console.log(err);
@@ -173,8 +177,6 @@ export const updateProperty = (property_id, property) => {
 
 		endpoint
 			.then(res => {
-				console.log('update property res', res.data);
-
 				dispatch({ type: PROPERTY_UPDATED, payload: res.data });
 			})
 			.catch(err => {

--- a/src/actions/propertyActions.js
+++ b/src/actions/propertyActions.js
@@ -241,7 +241,12 @@ export const getPartners = () => {
 
 		endpoint
 			.then(res => {
-				dispatch({ type: PARTNERS_FETCHED, payload: res.data.partners });
+				// send null payload if empty array
+				if(res.data.partners.length === 0){
+					dispatch({ type: PARTNERS_FETCHED, payload: null });
+				} else {
+					dispatch({ type: PARTNERS_FETCHED, payload: res.data.partners });
+				}
 			})
 			.catch(err => {
 				console.log(err);

--- a/src/actions/propertyActions.js
+++ b/src/actions/propertyActions.js
@@ -83,8 +83,12 @@ export const getUserProperties = () => {
 
 		fetchUrl
 			.then(res => {
-				// localStorage.setItem('userId', res.data.profile.id);
-				dispatch({ type: PROPERTIES_FETCHED, payload: res.data.properties });
+				// handle an empty array and return null if no properties found
+				if(res.data.properties.length === 0){
+					dispatch({ type: PROPERTIES_FETCHED, payload: null });
+				} else {
+					dispatch({ type: PROPERTIES_FETCHED, payload: res.data.properties });
+				}
 			})
 			.catch(err => {
 				console.log(err);

--- a/src/components/AddPropertyForm.js
+++ b/src/components/AddPropertyForm.js
@@ -7,10 +7,14 @@ import { withStyles } from '@material-ui/core';
 
 import { addProperty } from '../actions/propertyActions';
 
+import styled from 'styled-components';
+
 // Form Components
 
 import TextField from '@material-ui/core/TextField';
 import Button from '@material-ui/core/Button';
+import Tooltip from '@material-ui/core/Tooltip';
+import HelpTwoTone from '@material-ui/icons/HelpTwoTone';
 
 import Typography from '@material-ui/core/Typography';
 
@@ -30,6 +34,13 @@ const styles = {
 	}
 };
 
+const TopRow = styled.div`
+
+	display: flex;
+	flex-flow: row nowrap;
+	justify-content: space-between;
+	`;
+
 class AddPropertyForm extends React.Component {
 	constructor(props) {
 		super(props);
@@ -40,8 +51,8 @@ class AddPropertyForm extends React.Component {
 			address: '',
 			img_url: null,
 			cleaner_id: null,
-			guest_guide: null,
-			assistant_guide: null
+			guest_guide: '',
+			assistant_guide: ''
 		};
 	}
 
@@ -83,7 +94,13 @@ class AddPropertyForm extends React.Component {
 					noValidate
 					autoComplete="off"
 				>
+					<TopRow>
 					<Typography variant="h4">Add a New Property</Typography>
+					<Tooltip 
+					title = 'Guest Guide and Assistant Guide URLs will link to documents that outline guest and assistant guidelines, respectively.'>
+						<HelpTwoTone />
+					</Tooltip>
+					</TopRow>
 
 					<TextField
 						className={classes.formField}
@@ -99,17 +116,20 @@ class AddPropertyForm extends React.Component {
 						value={this.state.address}
 						onChange={this.handleInput('address')}
 					/>
+					
 					<TextField
 						className={classes.formField}
 						id="standard-dense"
-						label="Guest Guide URL"
+						label="Guest Guide URL (Optional)"
 						value={this.state.guest_guide}
 						onChange={this.handleInput('guest_guide')}
 					/>
+					
+
 					<TextField
 						className={classes.formField}
 						id="standard-dense"
-						label="Assistant Guide URL"
+						label="Assistant Guide URL (Optional)"
 						value={this.state.assistant_guide}
 						onChange={this.handleInput('assistant_guide')}
 					/>

--- a/src/components/Auth.js
+++ b/src/components/Auth.js
@@ -76,6 +76,8 @@ class Auth {
 		localStorage.removeItem('userInfo');
 		localStorage.removeItem('currentUser');
 		localStorage.removeItem('role');
+
+		localStorage.clear();
 	};
 }
 

--- a/src/components/Callback.js
+++ b/src/components/Callback.js
@@ -41,7 +41,7 @@ class Callback extends React.Component {
 	componentDidUpdate() {
 		if (this.props.userChecked === true) {
 			localStorage.removeItem('accountType');
-			this.props.history.replace('/reports');
+			this.props.history.replace('/properties');
 		}
 	}
 

--- a/src/components/Callback.js
+++ b/src/components/Callback.js
@@ -17,12 +17,16 @@ class Callback extends React.Component {
 
 		// handle invitation logins
 		if(localStorage.getItem('inviteCode')){
-			console.log('invite login');
 			await auth.handleAuthentication().then(status => {
-				console.log('login success, sending invite code');
+				
+				// the jwt is in localstorage, so complete the login flow
 				let role = localStorage.getItem('role');
 				let inviteCode = localStorage.getItem('inviteCode');
+
 				this.props.inviteLogin(role, inviteCode);
+
+				// remove the invite code from localstorage
+				localStorage.removeItem('inviteCode');
 			})
 		} else {
 			await auth.handleAuthentication().then(status => {

--- a/src/components/Callback.js
+++ b/src/components/Callback.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { checkIfUserExists } from '../actions/index';
+import { checkIfUserExists, inviteLogin } from '../actions/index';
 
 import Auth from './Auth';
 
@@ -14,10 +14,23 @@ const auth = new Auth();
 
 class Callback extends React.Component {
 	async componentDidMount() {
-		await auth.handleAuthentication().then(status => {
-			console.log('callback role', localStorage.getItem('accountType'));
-			this.props.checkIfUserExists(localStorage.getItem('accountType'));
-		});
+
+		// handle invitation logins
+		if(localStorage.getItem('inviteCode')){
+			console.log('invite login');
+			await auth.handleAuthentication().then(status => {
+				console.log('login success, sending invite code');
+				let role = localStorage.getItem('role');
+				let inviteCode = localStorage.getItem('inviteCode');
+				this.props.inviteLogin(role, inviteCode);
+			})
+		} else {
+			await auth.handleAuthentication().then(status => {
+				console.log('callback role', localStorage.getItem('accountType'));
+				this.props.checkIfUserExists(localStorage.getItem('accountType'));
+			});
+		}
+		
 	}
 
 	// @TODO callback redirect cant be properly resolved until backend is deployed
@@ -48,6 +61,7 @@ export default withRouter(
 		{
 			// actions
 			checkIfUserExists,
+			inviteLogin
 		}
 	)(Callback)
 );

--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -18,6 +18,9 @@ import PersonAddTwoTone from '@material-ui/icons/PersonAddTwoTone';
 import TimelapseTwoTone from '@material-ui/icons/TimelapseTwoTone';
 import NotificationsActiveTwoTone from '@material-ui/icons/NotificationsActiveTwoTone';
 
+import Auth from './Auth';
+const auth = new Auth;
+
 const FeatureGrid = styled.div`
     display: flex;
     flex-flow: row wrap;
@@ -91,6 +94,10 @@ class Home extends React.Component {
 
     }
 
+    handleLogin = () => {
+        auth.login();
+    }
+
     render(){
         return (
             <div>
@@ -144,7 +151,7 @@ class Home extends React.Component {
                 <CallToAction>
 
                 <Typography variant = 'h5'>Ready to simplify your property management tasks?</Typography>
-                <Button size = 'large' variant = 'contained' color = 'primary'>Sign Me Up!</Button>
+                <Button size = 'large' variant = 'contained' color = 'primary' onClick = {this.handleLogin}>Sign Me Up!</Button>
                 </CallToAction>
 
                 

--- a/src/components/Invite.js
+++ b/src/components/Invite.js
@@ -4,68 +4,46 @@ import { Link } from 'react-router-dom';
 import axios from 'axios';
 import { Typography } from '@material-ui/core';
 
+import Auth from './Auth';
+
+const auth = new Auth();
+
 class Invite extends Component {
+
+	componentDidMount(){
+		let inviteCode = this.props.history.location.search;
+		inviteCode = inviteCode.slice(1, inviteCode.length);
+		localStorage.setItem('inviteCode', inviteCode);
+	}
+
 	constructor(props) {
 		super(props);
 		this.state = {
-			successful: false,
+
 		};
 	}
 
-	async componentDidMount() {
-		const backendUrl =
-			process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`;
-		const inviteCode = this.props.match.params.invite_code;
-		let token = localStorage.getItem('jwt');
-		let userInfo = localStorage.getItem('userInfo');
-
-		let options = {
-			headers: {
-				Authorization: `Bearer ${token}`,
-				'user-info': userInfo,
-			},
-		};
-		const response = await axios.get(
-			`${backendUrl}/api/invites/accept/${inviteCode}`,
-			options
-		);
-		if (response) this.setState({ successful: true });
+	handleLogin = () => {
+		localStorage.setItem('role', 'assistant');
+		auth.login();
 	}
 
 	render() {
-		const loggedIn = localStorage.getItem('jwt');
 		return (
 			<div>
-				{loggedIn ? (
-					<div>
-						{this.state.successful ? (
-							<Typography variant="h6">
-								{' '}
-								Congratulations, your invitation has been processed
-								successfully! Click <Link to="/account">here </Link> to go to
-								your account page for more details{' '}
-							</Typography>
-						) : (
-							<Typography variant="h6">
-								{' '}
-								Unfortunately, your invitation was not successful. This may be
-								because you have already accepted an invitation from this user.{' '}
-								<br />
-								{/*<Link to="/account">Click here to go to your account page.</Link> Implement a current partners view in account page*/}
-							</Typography>
-						)}{' '}
-					</div>
-				) : (
-					<Typography variant="h6">
-						To process your invitation, you must be logged in. Please login or
-						create an account and then visit the invitation link given from your
-						email invitation.
-					</Typography>
-				)}
+			Welcome to WellBroomed!
+
+			To accept your invitation, please click below to create an account.
+			<button onClick = {this.handleLogin}>Sign Up</button>
+
+			If you already have an account, click here to log in.
+			<button onClick = {this.handleLogin}>Sign In</button>
 			</div>
 		);
 	}
 }
+
+
 function mapStateToProps(state) {
 	return {
 		user: state.authReducer.user,

--- a/src/components/Invite.js
+++ b/src/components/Invite.js
@@ -6,6 +6,8 @@ import { Typography } from '@material-ui/core';
 
 import {checkInvite} from '../actions/index';
 
+import Button from '@material-ui/core/Button';
+
 import Auth from './Auth';
 
 const auth = new Auth();
@@ -45,20 +47,22 @@ class Invite extends Component {
 		console.log(this.state.inviteInfo, 'invite info');
 		return (
 			<div>
+				<Typography variant = 'h2'>
 			Welcome to WellBroomed!
+			</Typography>
 			{this.state.inviteInfo ? (
 				<div>
-				You have been invited by {this.state.inviteInfo.manager_profile.user_name} to join WellBroomed!
+					<Typography variant = 'body1'>
+				You have been invited by <strong>{this.state.inviteInfo.manager_profile.user_name}</strong> ({this.state.inviteInfo.manager_profile.email}) to join WellBroomed!
+					</Typography>
 
-				Please login or create an account with your {this.state.inviteInfo.email} email address.
+				<Typography variant = 'h5'>
+				To accept your invitation, please click below and create an account with the email on your invitation ({this.state.inviteInfo.email}).
+				</Typography>
+				<Button variant = 'contained' color = 'primary' onClick = {this.handleLogin}>Accept</Button>
 				</div>
 			): (<div><h4>Loading invitation information...</h4></div>)}
 
-			To accept your invitation, please click below to create an account.
-			<button onClick = {this.handleLogin}>Sign Up</button>
-
-			If you already have an account, click here to log in.
-			<button onClick = {this.handleLogin}>Sign In</button>
 			</div>
 		);
 	}

--- a/src/components/Invite.js
+++ b/src/components/Invite.js
@@ -4,6 +4,8 @@ import { Link } from 'react-router-dom';
 import axios from 'axios';
 import { Typography } from '@material-ui/core';
 
+import {checkInvite} from '../actions/index';
+
 import Auth from './Auth';
 
 const auth = new Auth();
@@ -11,15 +13,26 @@ const auth = new Auth();
 class Invite extends Component {
 
 	componentDidMount(){
+		// parse and validate the invitation code
 		let inviteCode = this.props.history.location.search;
 		inviteCode = inviteCode.slice(1, inviteCode.length);
+		
+		this.props.checkInvite(inviteCode);
 		localStorage.setItem('inviteCode', inviteCode);
+	}
+
+	componentDidUpdate(prevProps){
+		if(prevProps.inviteInfo !== this.props.inviteInfo){
+			this.setState({
+				inviteInfo: this.props.inviteInfo
+			})
+		}
 	}
 
 	constructor(props) {
 		super(props);
 		this.state = {
-
+			inviteInfo: null,
 		};
 	}
 
@@ -29,9 +42,17 @@ class Invite extends Component {
 	}
 
 	render() {
+		console.log(this.state.inviteInfo, 'invite info');
 		return (
 			<div>
 			Welcome to WellBroomed!
+			{this.state.inviteInfo ? (
+				<div>
+				You have been invited by {this.state.inviteInfo.manager_profile.user_name} to join WellBroomed!
+
+				Please login or create an account with your {this.state.inviteInfo.email} email address.
+				</div>
+			): (<div><h4>Loading invitation information...</h4></div>)}
 
 			To accept your invitation, please click below to create an account.
 			<button onClick = {this.handleLogin}>Sign Up</button>
@@ -47,7 +68,14 @@ class Invite extends Component {
 function mapStateToProps(state) {
 	return {
 		user: state.authReducer.user,
+		inviteInfo: state.authReducer.inviteInfo,
 	};
 }
 
-export default connect(mapStateToProps)(Invite);
+export default connect(
+	mapStateToProps,
+	{
+		//actions
+		checkInvite,
+	}
+)(Invite);

--- a/src/components/Invite.js
+++ b/src/components/Invite.js
@@ -12,7 +12,41 @@ import {checkInvite} from '../actions/index';
 import Button from '@material-ui/core/Button';
 
 import Auth from './Auth';
-import { isObject } from 'util';
+
+import styled from 'styled-components';
+
+const TopBar = styled.div`
+	display: flex;
+	flex-flow: row nowrap;
+	justify-content: center;
+	margin-bottom: 20px;
+	`;
+
+const CardContainer = styled.div`
+
+	width: 100%;
+	display: flex;
+	flex-flow: column nowrap;
+	justify-content: center;
+	align-items: center;
+
+	div{
+		width: 50%;
+		text-align: center;
+	}
+
+	div > div{
+		width: 100%;
+		text-align: center;
+	}
+	
+	.action-box{
+		display: flex;
+		flex-flow: row nowrap;
+		justify-content: center;
+	}
+
+	`;
 
 const auth = new Auth();
 
@@ -51,27 +85,32 @@ class Invite extends Component {
 		console.log(this.state.inviteInfo, 'invite info');
 		return (
 			<div>
-				<Typography variant = 'h2'>
+			<TopBar>
+			<Typography variant = 'h2'>
 			Welcome to WellBroomed!
 			</Typography>
+			</TopBar>
 			{this.state.inviteInfo ? (
 				<div>
+					<CardContainer>
 					<Card>
 						<CardContent>
-							<Typography variant = 'body1'>
-								You have been invited by <strong>{this.state.inviteInfo.manager_profile.user_name}</strong> ({this.state.inviteInfo.manager_profile.email}) to join WellBroomed!
+							<Typography variant = 'h5'>
+								You have been invited by <strong>{this.state.inviteInfo.manager_profile.user_name}</strong> ({this.state.inviteInfo.manager_profile.email}) to join WellBroomed.
 							</Typography>
 
-							<Typography variant = 'h5'>
+							<Typography variant = 'body1'>
 								To accept your invitation, please click below and create an account with the email on your invitation ({this.state.inviteInfo.email}).
 							</Typography>
 						</CardContent>
 						
 						<CardActions>
+							<div className = 'action-box'>
 							<Button variant = 'contained' color = 'primary' onClick = {this.handleLogin}>Accept</Button>
+							</div>
 						</CardActions>
 					</Card>
-					
+					</CardContainer>
 				
 				</div>
 			): (<div><h4>Loading invitation information...</h4></div>)}

--- a/src/components/Invite.js
+++ b/src/components/Invite.js
@@ -1,14 +1,18 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
-import axios from 'axios';
-import { Typography } from '@material-ui/core';
+
+// Material UI
+import Typography from '@material-ui/core/Typography';
+import Card from '@material-ui/core/Card';
+import CardContent from '@material-ui/core/CardContent';
+import CardActions from '@material-ui/core/CardActions';
 
 import {checkInvite} from '../actions/index';
 
 import Button from '@material-ui/core/Button';
 
 import Auth from './Auth';
+import { isObject } from 'util';
 
 const auth = new Auth();
 
@@ -52,14 +56,23 @@ class Invite extends Component {
 			</Typography>
 			{this.state.inviteInfo ? (
 				<div>
-					<Typography variant = 'body1'>
-				You have been invited by <strong>{this.state.inviteInfo.manager_profile.user_name}</strong> ({this.state.inviteInfo.manager_profile.email}) to join WellBroomed!
-					</Typography>
+					<Card>
+						<CardContent>
+							<Typography variant = 'body1'>
+								You have been invited by <strong>{this.state.inviteInfo.manager_profile.user_name}</strong> ({this.state.inviteInfo.manager_profile.email}) to join WellBroomed!
+							</Typography>
 
-				<Typography variant = 'h5'>
-				To accept your invitation, please click below and create an account with the email on your invitation ({this.state.inviteInfo.email}).
-				</Typography>
-				<Button variant = 'contained' color = 'primary' onClick = {this.handleLogin}>Accept</Button>
+							<Typography variant = 'h5'>
+								To accept your invitation, please click below and create an account with the email on your invitation ({this.state.inviteInfo.email}).
+							</Typography>
+						</CardContent>
+						
+						<CardActions>
+							<Button variant = 'contained' color = 'primary' onClick = {this.handleLogin}>Accept</Button>
+						</CardActions>
+					</Card>
+					
+				
 				</div>
 			): (<div><h4>Loading invitation information...</h4></div>)}
 

--- a/src/components/Invite.js
+++ b/src/components/Invite.js
@@ -20,6 +20,7 @@ const TopBar = styled.div`
 	flex-flow: row nowrap;
 	justify-content: center;
 	margin-bottom: 20px;
+	text-align: center;
 	`;
 
 const CardContainer = styled.div`
@@ -31,7 +32,7 @@ const CardContainer = styled.div`
 	align-items: center;
 
 	div{
-		width: 50%;
+		width: 75%;
 		text-align: center;
 	}
 

--- a/src/components/PartnerCard.js
+++ b/src/components/PartnerCard.js
@@ -112,44 +112,54 @@ class PartnerCard extends React.Component {
 
 	render() {
 		const { classes, partner, defaultProperties } = this.props;
-
-		const defaultPropertyList = partner.defaultProperties
-			.map(property => ({
-				...property,
-				property_name: property.property_name + ' - click to unassign',
-			}))
-			.concat(
-				defaultProperties
-					.filter(
+		let defaultPropertyList = [];
+		if(partner.defaultProperties){
+			if(partner.defaultProperties.length > 0){
+				defaultPropertyList = partner.defaultProperties
+				.map(property => ({
+					...property,
+					property_name: property.property_name + ' - click to unassign',
+				}))
+				.concat(
+					defaultProperties
+						.filter(
+							({ property_id }) =>
+								!partner.defaultProperties.find(
+									property => property.property_id === property_id
+								)
+						)
+						.map(property => ({
+							...property,
+							property_name:
+								property.property_name +
+								(property.cleaner_name
+									? ` - currently assigned to ${property.cleaner_name}`
+									: ''),
+						}))
+				);
+			}
+		}
+		
+		// These conditionals are necessary to prevent mapping undefined values (e.g. []) that will crash the application
+		let availablePropertyList = []
+		if(partner.availableProperties){
+			if(partner.availableProperties.length > 0){
+				partner.availableProperties
+				.map(property => ({
+					...property,
+					property_name: property.property_name + ' - click to unassign',
+				}))
+				.concat(
+					defaultProperties.filter(
 						({ property_id }) =>
-							!partner.defaultProperties.find(
+							!partner.availableProperties.find(
 								property => property.property_id === property_id
 							)
 					)
-					.map(property => ({
-						...property,
-						property_name:
-							property.property_name +
-							(property.cleaner_name
-								? ` - currently assigned to ${property.cleaner_name}`
-								: ''),
-					}))
-			);
-
-		const availablePropertyList = partner.availableProperties
-			.map(property => ({
-				...property,
-				property_name: property.property_name + ' - click to unassign',
-			}))
-			.concat(
-				defaultProperties.filter(
-					({ property_id }) =>
-						!partner.availableProperties.find(
-							property => property.property_id === property_id
-						)
-				)
-			);
-
+				);
+			}
+		}
+		
 		return (
 			<div>
 				<Card key={partner.cleaner_id} className={classes.card}>

--- a/src/components/PartnerCard.js
+++ b/src/components/PartnerCard.js
@@ -122,7 +122,7 @@ class PartnerCard extends React.Component {
 					property_name: property.property_name + ' - click to unassign',
 				}))
 				.concat(
-					defaultProperties
+					partner.defaultProperties
 						.filter(
 							({ property_id }) =>
 								!partner.defaultProperties.find(
@@ -143,15 +143,15 @@ class PartnerCard extends React.Component {
 		
 		// These conditionals are necessary to prevent mapping undefined values (e.g. []) that will crash the application
 		let availablePropertyList = []
-		if(partner.availableProperties){
-			if(partner.availableProperties.length > 0){
+		if(partner.availableProperties && defaultProperties){
+			if(partner.availableProperties.length > 0 && defaultProperties.length > 0){
 				availablePropertyList = partner.availableProperties
 				.map(property => ({
 					...property,
 					property_name: property.property_name + ' - click to unassign',
 				}))
 				.concat(
-					defaultProperties.filter(
+					partner.defaultProperties.filter(
 						({ property_id }) =>
 							!partner.availableProperties.find(
 								property => property.property_id === property_id
@@ -283,23 +283,28 @@ class PartnerCard extends React.Component {
 								partner.cleaner_name
 							}'s Available Properties`}</DialogTitle>
 							<List>
-								{availablePropertyList.map(property => (
-									<ListItem
-										button
-										selected={
-											partner.availableProperties.find(
-												({ property_id }) =>
-													property_id === property.property_id
-											)
-												? true
-												: false
-										}
-										onClick={() => this.handleAvailableDialogClose(property)}
-										key={property.property_id}
-									>
-										<ListItemText primary={property.property_name} />
-									</ListItem>
-								))}
+								{availablePropertyList.length > 0 ? (
+									<>
+									{availablePropertyList.map(property => (
+										<ListItem
+											button
+											selected={
+												partner.availableProperties.find(
+													({ property_id }) =>
+														property_id === property.property_id
+												)
+													? true
+													: false
+											}
+											onClick={() => this.handleAvailableDialogClose(property)}
+											key={property.property_id}
+										>
+											<ListItemText primary={property.property_name} />
+										</ListItem>
+									))}
+									</>
+								) : (null)}
+								
 							</List>
 						</Dialog>
 					</Paper>

--- a/src/components/PartnerCard.js
+++ b/src/components/PartnerCard.js
@@ -70,16 +70,18 @@ class PartnerCard extends React.Component {
 			let defaultproperties = [];
 			let availableproperties = [];
 
-			properties.forEach(property => {
-				if (property.cleaner_id === this.props.partner.user_id)
-					defaultproperties.push(property);
-				if (
-					property.available_cleaners.some(
-						cleaner => cleaner['cleaner_id'] === this.props.partner.user_id
-					)
-				)
-					availableproperties.push(property);
-			});
+			
+				properties.forEach(property => {
+					if (property.cleaner_id === this.props.partner.user_id)
+						defaultproperties.push(property);
+						// This is bugging the site
+					// if (
+					// 	property.available_cleaners.some(
+					// 		cleaner => cleaner['cleaner_id'] === this.props.partner.user_id
+					// 	)
+					// )
+						availableproperties.push(property);
+				});	
 
 			this.setState({ defaultproperties, availableproperties, properties });
 		}
@@ -266,7 +268,8 @@ class PartnerCard extends React.Component {
 const mapStateToProps = state => {
 	return {
 		// state items
-		properties: state.propertyReducer.properties
+		properties: state.propertyReducer.properties,
+		partners: state.propertyReducer.partners,
 	};
 };
 

--- a/src/components/PartnerCard.js
+++ b/src/components/PartnerCard.js
@@ -112,6 +112,7 @@ class PartnerCard extends React.Component {
 
 	render() {
 		const { classes, partner, defaultProperties } = this.props;
+		// These conditionals are necessary to prevent mapping undefined values (e.g. []) that will crash the application
 		let defaultPropertyList = [];
 		if(partner.defaultProperties){
 			if(partner.defaultProperties.length > 0){
@@ -144,7 +145,7 @@ class PartnerCard extends React.Component {
 		let availablePropertyList = []
 		if(partner.availableProperties){
 			if(partner.availableProperties.length > 0){
-				partner.availableProperties
+				availablePropertyList = partner.availableProperties
 				.map(property => ({
 					...property,
 					property_name: property.property_name + ' - click to unassign',

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -24,7 +24,7 @@ import { withStyles } from '@material-ui/core';
 import styled from 'styled-components';
 
 //Actions
-import { getPartners, getUserProperties, sendInvite } from '../actions';
+import { getPartners, getUserProperties, sendInvite, getAllInvites, } from '../actions';
 
 //Component
 import PartnerCard from './PartnerCard';
@@ -67,6 +67,7 @@ class Partners extends React.Component {
 		}
 
 		this.props.getPartners();
+		this.props.getAllInvites();
 	}
 
 
@@ -201,6 +202,7 @@ export default withRouter(
 			getPartners,
 			getUserProperties,
 			sendInvite,
+			getAllInvites,
 		}
 	)(withStyles(styles)(Partners))
 );

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -177,8 +177,8 @@ class Partners extends React.Component {
 
 
 
-				{this.props.cleaners ? (
-					this.props.cleaners.map(partner => {
+				{this.props.partners ? (
+					this.props.partners.map(partner => {
 						return <PartnerCard partner={partner} key={partner.user_id} />;
 					})
 				) : (

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -159,7 +159,7 @@ class Partners extends React.Component {
 	}
 
 	render() {
-		const { classes, user, partners, defaultProperties } = this.props;
+		const { classes } = this.props;
 
 		return (
 			<div>
@@ -186,7 +186,6 @@ class Partners extends React.Component {
 						No partners have been added yet.
 					</Typography>
 				)}
-				<div className={classes.invite}>
 					
 					{/** Email Modal */}
 					<Dialog open = {this.state.emailModal} onClose = {this.toggleEmail} maxWidth = 'xl' fullWidth = {true}>
@@ -213,7 +212,6 @@ class Partners extends React.Component {
 								</>)}
 						
 					</Dialog>
-					</div>
 
 
 					{/** Invitations Table **/}

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -108,6 +108,10 @@ class Partners extends React.Component {
 		if(this.props.refreshCleaners !== prevProps.refreshCleaners){
 			this.props.getPartners();
 		}
+
+		if(this.props.refreshInvites !== prevProps.refreshInvites){
+			this.props.getAllInvites();
+		}
 	}
 
 	constructor(props) {
@@ -186,7 +190,7 @@ class Partners extends React.Component {
 					})
 				) : (
 					<Typography variant="overline">
-						No partners have been invited yet.
+						No partners have been added yet.
 					</Typography>
 				)}
 				<div className={classes.invite}>
@@ -246,7 +250,9 @@ class Partners extends React.Component {
 						</TableBody>
 					</Table>
 					</Paper>
-					) : (<>Loading invitations...</>)}
+					) : (<>
+						<Typography variant = 'overline'>No Invitations Have Been Sent</Typography>
+						</>)}
 
 					
 
@@ -264,6 +270,7 @@ const mapStateToProps = state => {
 		refreshCleaners: state.propertyReducer.refreshCleaners,
 		refreshProperties: state.propertyReducer.refreshProperties,
 		invites: state.partnerReducer.invites,
+		refreshInvites: state.partnerReducer.refreshInvites,
 	};
 };
 

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -14,7 +14,7 @@ import Typography from '@material-ui/core/Typography';
 import { withStyles } from '@material-ui/core';
 
 //Actions
-import { getPartners, getUserProperties } from '../actions';
+import { getPartners, getUserProperties, sendInvite } from '../actions';
 
 //Component
 import PartnerCard from './PartnerCard';
@@ -83,35 +83,16 @@ class Partners extends React.Component {
 		});
 	}
 
-	sendEmail = async e => {
-		if (!this.state.email) return;
-		e.preventDefault();
-		console.log('sending email');
+	handleSubmit = event => {
+		console.log(this.state.email);
 
-		let token = localStorage.getItem('jwt');
-		let userInfo = localStorage.getItem('userInfo');
+		this.props.sendInvite(this.state.email);
 
-		let options = {
-			headers: {
-				Authorization: `Bearer ${token}`,
-				'user-info': userInfo
-			}
-		};
+		this.setState({
+			email: ''
+		})
 
-		let body = {
-			cleaner_email: this.state.email
-		};
-
-		const backendUrl = process.env.REACT_APP_BACKEND_URL || 'http://localhost:5000';
-		try {
-			const res = await axios.post(`${backendUrl}/api/invites/`, body, options);
-			console.log(res);
-		} catch (err) {
-			console.log(err);
-		}
-
-		this.setState({email: ''});
-	};
+	}
 
 	render() {
 		const { classes } = this.props;
@@ -139,7 +120,7 @@ class Partners extends React.Component {
 						type="text"
 						name="email"
 					/>
-					<Button type="submit" onClick={this.sendEmail}>
+					<Button type="submit" onClick={this.handleSubmit}>
 						Send Invite
 					</Button>
 				</div>
@@ -164,7 +145,8 @@ export default withRouter(
 		{
 			// actions
 			getPartners,
-			getUserProperties
+			getUserProperties,
+			sendInvite,
 		}
 	)(withStyles(styles)(Partners))
 );

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -76,17 +76,6 @@ const TopBar = styled.div`
 	align-items: center;
 `;
 
-const TableContainer = styled.div`
-	width: 100%;
-
-	div{
-		width: 100%;
-	}
-	table{
-		width: 100%; 
-	}
-	`;
-
 class Partners extends React.Component {
 
 	componentDidMount() {

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -6,6 +6,8 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 // Axios
 import axios from 'axios';
+
+import moment from 'moment';
 //Material-UI
 import {
 	TextField, 
@@ -15,7 +17,14 @@ import {
 	Dialog, 
 	DialogTitle, 
 	DialogContent, 
-	DialogActions} from '@material-ui/core';
+	DialogActions,
+	Table,
+	TableHead,
+	TableRow,
+	TableCell,
+	TableBody,
+	Paper,
+	} from '@material-ui/core';
 
 import AddIcon from '@material-ui/icons/Add';
 
@@ -30,6 +39,9 @@ import { getPartners, getUserProperties, sendInvite, getAllInvites, } from '../a
 import PartnerCard from './PartnerCard';
 
 const styles = {
+	root: {
+		width: '100%',
+	},
 	card: {
 		maxWidth: 600,
 		margin: '20px auto'
@@ -46,6 +58,12 @@ const styles = {
 	},
 	contentTypography: {
 		margin: 'auto'
+	},
+	table: {
+		minWidth: 650,
+	},
+	paper: {
+		width: '100%'
 	}
 };
 
@@ -58,6 +76,16 @@ const TopBar = styled.div`
 	align-items: center;
 `;
 
+const TableContainer = styled.div`
+	width: 100%;
+
+	div{
+		width: 100%;
+	}
+	table{
+		width: 100%; 
+	}
+	`;
 
 class Partners extends React.Component {
 
@@ -124,6 +152,16 @@ class Partners extends React.Component {
 		}, 2000);
 	}
 
+	parseStatus = (status) => {
+		if(status === 0){
+			return 'Pending';
+		} else if(status === 1){
+			return 'Accepted';
+		} else if(status === 2){
+			return 'Rejected';
+		}
+	}
+
 	render() {
 		const { classes } = this.props;
 		return (
@@ -178,7 +216,41 @@ class Partners extends React.Component {
 								</>)}
 						
 					</Dialog>
-				</div>
+					</div>
+
+
+					{/** Invitations Table **/}
+					<Typography variant = 'h2'>Invitations</Typography>
+					{this.props.invites ? (
+						<Paper className = {classes.paper}>
+						<Table size = 'small' className = {classes.table}>
+						<TableHead>
+							<TableRow>
+								<TableCell>Partner Email</TableCell>
+								<TableCell align = 'right'>Invite Code</TableCell>
+								<TableCell align = 'right'>Created At</TableCell>
+								<TableCell align = 'right'>Status</TableCell>
+							</TableRow>
+						</TableHead>
+						<TableBody>
+							{this.props.invites.map(invite => (
+								<TableRow key = {invite.createdAt}>
+									<TableCell component = 'th' scope = 'row'>
+										{invite.email}
+									</TableCell>
+									<TableCell align = 'right'>{invite.inviteCode}</TableCell>
+									<TableCell align = 'right'>{moment(invite.createdAt).format('LLL')}</TableCell>
+									<TableCell align = 'right'>{this.parseStatus(invite.status)}</TableCell>
+								</TableRow>
+							))}
+						</TableBody>
+					</Table>
+					</Paper>
+					) : (<>Loading invitations...</>)}
+
+					
+
+
 			</div>
 		);
 	}
@@ -190,7 +262,8 @@ const mapStateToProps = state => {
 		properties: state.propertyReducer.properties,
 		cleaners: state.propertyReducer.partners,
 		refreshCleaners: state.propertyReducer.refreshCleaners,
-		refreshProperties: state.propertyReducer.refreshProperties
+		refreshProperties: state.propertyReducer.refreshProperties,
+		invites: state.partnerReducer.invites,
 	};
 };
 

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -66,7 +66,7 @@ class Properties extends React.Component {
 			this.props.history.replace('/');
 		}
 
-		this.props.getUserProperties();
+		// this.props.getUserProperties();
 	}
 
 	componentDidUpdate(prevProps) {

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -59,11 +59,11 @@ class Properties extends React.Component {
 		if (!localStorage.getItem('jwt')) {
 			this.props.history.replace('/');
 		}
+
 		this.props.getUserProperties();
 	}
 
 	componentDidUpdate(prevProps) {
-		// refreshProperties will be set to true once the user is checked
 		if (prevProps.refreshProperties !== this.props.refreshProperties) {
 			this.props.getUserProperties();
 		}
@@ -192,7 +192,6 @@ class Properties extends React.Component {
 							You have not made yourself available to any properties.
 						</Typography>
 					)}
-
 					{otherProperties.length ? (
 						<React.Fragment>
 							<Typography variant="h5" className={classes.title}>
@@ -211,17 +210,14 @@ class Properties extends React.Component {
 		}
 	}
 }
-
 const mapStateToProps = state => {
 	return {
 		// state items
 		user: state.authReducer.user,
 		properties: state.propertyReducer.properties,
 		refreshProperties: state.propertyReducer.refreshProperties,
-		userChecked: state.authReducer.userChecked,
 	};
 };
-
 export default withRouter(
 	connect(
 		mapStateToProps,

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -65,16 +65,11 @@ class Properties extends React.Component {
 		if (!localStorage.getItem('jwt')) {
 			this.props.history.replace('/');
 		}
-
-		// this.props.getUserProperties();
 	}
 
 	componentDidUpdate(prevProps) {
+		// refreshProperties will be set to true once the user is checked
 		if (prevProps.refreshProperties !== this.props.refreshProperties) {
-			this.props.getUserProperties();
-		}
-
-		if(prevProps.userChecked !== this.props.userChecked){
 			this.props.getUserProperties();
 		}
 	}

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -32,6 +32,7 @@ import AddIcon from '@material-ui/icons/Add';
 // Actions
 import { getUserProperties } from '../actions';
 import PropertyPreview from './PropertyPreview';
+import { thisExpression } from '@babel/types';
 
 const TopBar = styled.div`
 	width: 100%;
@@ -70,6 +71,10 @@ class Properties extends React.Component {
 
 	componentDidUpdate(prevProps) {
 		if (prevProps.refreshProperties !== this.props.refreshProperties) {
+			this.props.getUserProperties();
+		}
+
+		if(prevProps.userChecked !== this.props.userChecked){
 			this.props.getUserProperties();
 		}
 	}
@@ -196,6 +201,7 @@ const mapStateToProps = state => {
 		user: state.authReducer.user,
 		properties: state.propertyReducer.properties,
 		refreshProperties: state.propertyReducer.refreshProperties,
+		userChecked: state.authReducer.userChecked,
 	};
 };
 

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -65,6 +65,7 @@ class Properties extends React.Component {
 		if (!localStorage.getItem('jwt')) {
 			this.props.history.replace('/');
 		}
+		this.props.getUserProperties();
 	}
 
 	componentDidUpdate(prevProps) {
@@ -126,7 +127,7 @@ class Properties extends React.Component {
 						</DialogContent>
 					</Dialog>
 
-					{properties && user.user_id ? (
+					{this.props.properties && user.user_id ? (
 						properties.map(property => {
 							return (
 								<PropertyPreview

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -39,11 +39,16 @@ const TopBar = styled.div`
 	flex-flow: row nowrap;
 	justify-content: space-between;
 	align-items: center;
-	margin: 0 0 20px;
 `;
 
 const styles = {
-	title: { padding: '10px 0 0' },
+	card: {
+		maxWidth: 600,
+		margin: '20px auto',
+	},
+	media: {
+		objectFit: 'cover',
+	},
 	addIcon: {
 		fontSize: '5rem',
 		cursor: 'pointer',
@@ -59,11 +64,11 @@ class Properties extends React.Component {
 		if (!localStorage.getItem('jwt')) {
 			this.props.history.replace('/');
 		}
-
 		this.props.getUserProperties();
 	}
 
 	componentDidUpdate(prevProps) {
+		// refreshProperties will be set to true once the user is checked
 		if (prevProps.refreshProperties !== this.props.refreshProperties) {
 			this.props.getUserProperties();
 		}
@@ -95,9 +100,7 @@ class Properties extends React.Component {
 		const role = (this.props.user && this.props.user.role) || null;
 		const { user, properties } = this.props;
 
-		if (!(properties && user.user_id)) {
-			return null;
-		} else if (role === 'manager')
+		if (role === 'manager')
 			return (
 				<div>
 					<TopBar>
@@ -123,7 +126,7 @@ class Properties extends React.Component {
 						</DialogContent>
 					</Dialog>
 
-					{properties.length ? (
+					{this.props.properties && user.user_id ? (
 						properties.map(property => {
 							return (
 								<PropertyPreview
@@ -139,75 +142,51 @@ class Properties extends React.Component {
 					)}
 				</div>
 			);
-		else {
-			const defaultProperties = properties.filter(
-				({ cleaner_id }) => cleaner_id === user.user_id
-			);
-
-			const availableProperties = properties.filter(
-				({ cleaner_id, available }) => cleaner_id !== user.user_id && available
-			);
-
-			const otherProperties = properties.filter(
-				({ cleaner_id, available }) => cleaner_id !== user.user_id && !available
-			);
-
+		else
 			return (
 				<div>
 					<TopBar>
 						<Typography variant="h2">Properties</Typography>{' '}
 					</TopBar>
-					{defaultProperties.length ? (
-						<React.Fragment>
-							<Typography variant="h5" className={classes.title}>
-								Your Default Properties
-							</Typography>
-							{properties
-								.filter(({ cleaner_id }) => cleaner_id === user.user_id)
-								.map(property => {
-									return (
-										<PropertyPreview
-											property={property}
-											key={property.property_id}
-										/>
-									);
-								})}
-						</React.Fragment>
-					) : null}
-
-					<Typography variant="h5" className={classes.title}>
-						Properties You're Available For
-					</Typography>
-					{availableProperties.length ? (
-						availableProperties.map(property => {
-							return (
-								<PropertyPreview
-									property={property}
-									key={property.property_id}
-								/>
-							);
-						})
+					<Typography variant="h5"> Your Default Properties </Typography>
+					{properties && user.user_id ? (
+						properties
+							.filter(({ cleaner_id }) => cleaner_id === user.user_id)
+							.map(property => {
+								return (
+									<PropertyPreview
+										property={property}
+										key={property.property_id}
+									/>
+								);
+							})
 					) : (
 						<Typography variant="overline">
-							You have not made yourself available to any properties.
+							You have not been assigned as the default partner for any
+							properties.
 						</Typography>
 					)}
-					{otherProperties.length ? (
-						<React.Fragment>
-							<Typography variant="h5" className={classes.title}>
-								Other Properties
-							</Typography>
-							{otherProperties.map(property => (
-								<PropertyPreview
-									property={property}
-									key={property.property_id}
-								/>
-							))}
-						</React.Fragment>
-					) : null}
+
+					<Typography variant="h5">Properties You're Available For </Typography>
+					{properties && user.user_id ? (
+						properties
+							.filter(({ available }) => available)
+							.map(property => {
+								return (
+									<PropertyPreview
+										property={property}
+										key={property.property_id}
+									/>
+								);
+							})
+					) : (
+						<Typography variant="overline">
+							You have not been assigned as the default partner for any
+							properties.
+						</Typography>
+					)}
 				</div>
 			);
-		}
 	}
 }
 const mapStateToProps = state => {
@@ -216,6 +195,7 @@ const mapStateToProps = state => {
 		user: state.authReducer.user,
 		properties: state.propertyReducer.properties,
 		refreshProperties: state.propertyReducer.refreshProperties,
+		userChecked: state.authReducer.userChecked,
 	};
 };
 export default withRouter(

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -31,11 +31,7 @@ import { withRouter, Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 
 // Actions
-import {
-	changeCleaner,
-	deleteProperty,
-	changeAvailableCleaner,
-} from '../actions/propertyActions';
+import { changeCleaner, deleteProperty } from '../actions/propertyActions';
 
 const CardContainer = styled.div`
 	width: 100%;
@@ -43,7 +39,6 @@ const CardContainer = styled.div`
 	flex-flow: row nowrap;
 	justify-content: space-between;
 	padding: 20px;
-
 	a {
 		color: black;
 		text-decoration: none;
@@ -67,7 +62,6 @@ const CardActions = styled.div`
 	flex-flow: row nowrap;
 	align-items: flex-start;
 	justify-content: flex-end;
-
 	svg {
 		cursor: pointer;
 		font-size: 3rem;
@@ -76,8 +70,8 @@ const CardActions = styled.div`
 
 const styles = {
 	card: {
-		maxWidth: '600px',
-		margin: '12px 0 20px 0',
+		maxWidth: '100%',
+		margin: '20px auto',
 	},
 	media: {
 		objectFit: 'cover',
@@ -86,11 +80,6 @@ const styles = {
 		margin: '20px',
 		minWidth: 120,
 	},
-	available: {
-		display: 'flex',
-		justifyContent: 'flex-end',
-	},
-	button: { width: '196px' },
 };
 
 class PropertyPreview extends React.Component {
@@ -113,14 +102,6 @@ class PropertyPreview extends React.Component {
 		this.props.changeCleaner(
 			this.props.property.property_id,
 			event.target.value || null
-		);
-	};
-
-	handleMakeAvailable = available => {
-		this.props.changeAvailableCleaner(
-			this.props.property.property_id,
-			null,
-			available
 		);
 	};
 
@@ -261,28 +242,7 @@ class PropertyPreview extends React.Component {
 						/>
 					</Link>
 
-					<CardContent className={classes.available}>
-						{property.cleaner_id !== user.user_id &&
-							(property.available ? (
-								<Button
-									className={classes.button}
-									variant="contained"
-									color="default"
-									onClick={() => this.handleMakeAvailable(false)}
-								>
-									Mark as Unavailable
-								</Button>
-							) : (
-								<Button
-									className={classes.button}
-									variant="contained"
-									color="primary"
-									onClick={() => this.handleMakeAvailable(true)}
-								>
-									Mark as Available
-								</Button>
-							))}
-					</CardContent>
+					<CardContent />
 				</Card>
 			);
 		}
@@ -303,7 +263,6 @@ export default withRouter(
 			// actions
 			changeCleaner,
 			deleteProperty,
-			changeAvailableCleaner,
 		}
 	)(withStyles(styles)(PropertyPreview))
 );

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -47,7 +47,13 @@ const CardContainer = styled.div`
 	}
 `;
 
-const CardText = styled.div``;
+const CardText = styled.div`
+	transition: color 0.1s ease-in-out;
+	:hover{
+			color: #3f51b5;
+			transition: color 0.2s ease-in-out;
+		}
+	`;
 
 const CardFooter = styled.div``;
 

--- a/src/components/__App/App.js
+++ b/src/components/__App/App.js
@@ -42,18 +42,6 @@ class App extends Component {
 				localStorage.getItem('accountType') || localStorage.getItem('role')
 			);
 		}
-
-		if (
-			(localStorage.getItem('isLoggedIn') &&
-				!localStorage.getItem('userInfo')) ||
-			!localStorage.getItem('currentUser')
-		) {
-			this.props.checkIfUserExists(
-				localStorage.getItem('accountType') || localStorage.getItem('role')
-			);
-		} else if (!this.props.user && localStorage.getItem('currentUser')) {
-			this.props.setUser(JSON.parse(localStorage.getItem('currentUser')));
-		}
 	}
 
 	render() {

--- a/src/components/__App/App.js
+++ b/src/components/__App/App.js
@@ -37,6 +37,12 @@ const ComponentContainer = styled.div`
 
 class App extends Component {
 	componentDidMount() {
+		if(!this.props.userChecked){
+			this.props.checkIfUserExists(
+				localStorage.getItem('accountType') || localStorage.getItem('role')
+			);
+		}
+
 		if (
 			(localStorage.getItem('isLoggedIn') &&
 				!localStorage.getItem('userInfo')) ||

--- a/src/components/__App/App.js
+++ b/src/components/__App/App.js
@@ -69,7 +69,7 @@ class App extends Component {
 							<Route exact path="/account" component={Account} />
 							<Route path="/callback" component={Callback} />
 							<Route path="/redirect" component={Redirect} />
-							<Route path="/invite/:invite_code" component={Invite} />
+							<Route path="/invite" component={Invite} />
 						</Switch>
 					</ComponentContainer>
 				</MuiPickersUtilsProvider>

--- a/src/reducers/authReducer.js
+++ b/src/reducers/authReducer.js
@@ -3,6 +3,7 @@ import {
 	USER_UPDATED,
 	UPDATING_USER,
 	SET_USER,
+	INVITE_FETCHED,
 } from '../actions';
 
 const initialState = {
@@ -10,6 +11,7 @@ const initialState = {
 	userChecked: false,
 	user: null,
 	currentUser: null,
+	inviteInfo: null,
 };
 
 const authReducer = (state = initialState, action) => {
@@ -29,6 +31,11 @@ const authReducer = (state = initialState, action) => {
 				...state,
 				userChecked: false,
 			};
+		case INVITE_FETCHED:
+				return {
+					...state,
+					inviteInfo: action.payload,
+				}
 
 		case USER_UPDATED:
 			return {

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -3,10 +3,12 @@ import authReducer from './authReducer';
 import propertyReducer from './propertyReducer';
 import guestReducer from './guestReducer';
 import reportsReducer from './reportsReducer';
+import partnerReducer from './partnerReducer';
 
 export default combineReducers({
 	authReducer,
 	propertyReducer,
 	guestReducer,
-	reportsReducer
+	reportsReducer,
+	partnerReducer,
 });

--- a/src/reducers/partnerReducer.js
+++ b/src/reducers/partnerReducer.js
@@ -1,0 +1,25 @@
+import {
+    INVITES_FETCHED,
+    
+    ERROR,
+} from '../actions';
+
+const initialState = {
+	invites: null,
+};
+
+const partnerReducer = (state = initialState, action) => {
+	switch (action.type) {
+        // example action
+        case INVITES_FETCHED:
+            return {
+                ...state,
+                invites: action.payload,
+            }
+		
+		default:
+			return state;
+	}
+};
+
+export default partnerReducer;

--- a/src/reducers/partnerReducer.js
+++ b/src/reducers/partnerReducer.js
@@ -1,20 +1,27 @@
 import {
     INVITES_FETCHED,
-    
+    INVITE_SENT,
     ERROR,
 } from '../actions';
 
 const initialState = {
+    refreshInvites: false,
 	invites: null,
 };
 
 const partnerReducer = (state = initialState, action) => {
 	switch (action.type) {
-        // example action
+        case INVITE_SENT:
+            return {
+                ...state,
+                refreshInvites: true,
+            }
+    
         case INVITES_FETCHED:
             return {
                 ...state,
                 invites: action.payload,
+                refreshInvites: false,
             }
 		
 		default:


### PR DESCRIPTION
Adds consistent functionality to the partners page (i.e. modal windows for email input, same as properties and guests)

Adds an invitations table where you can monitor invitations that have been sent. This still needs to be conditional for manager/partner views, I was thinking of having the partners view list the properties the manager has. 

Invitation system has been cleaned up a bit, codes are passed as query parameters, and the invitation acceptance screen populates with information about the invite itself (who sent it, what email is expected, etc.)

A minor issue with google log-ins, though, as they don't always prompt for account selection. The email of the new account has to match the email on the invitation or it will not process properly and create a manager-partner link. I've added this as a bug in trello.

There is still some major bug that's crashing the server from time to time, I think it's something to do with the Properties page and the queries it is hitting on the backend, as that's the place I've seen it crash most often. It seems to be a recent change, but I'm having trouble tracking it down. 