### PR TITLE
Guest Filter Tabs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-  <title>React App</title>
+  <title>WellBroomed</title>
 </head>
 
 <body>

--- a/src/components/Guests.js
+++ b/src/components/Guests.js
@@ -159,42 +159,65 @@ class Guests extends React.Component {
 							</Tabs>
 						</AppBar>
 						<br></br>
-			
+					
+						{/** Upcoming Guests **/}
 						{this.state.tab === 0 ? (
-							<>
-							{upcomingGuests.map(guest => {
-								return (
-									<GuestPreview guest = {guest} tab = {this.state.tab} key = {guest.guest_id} fetching = {this.props.gettingPropertyCleaners} />
-								)
-							})}
-							</>
-						) : (null)}
+								<>
+								{upcomingGuests.length > 0 ? (
+									upcomingGuests.map(guest => {
+										return (
+											<GuestPreview guest = {guest} tab = {this.state.tab} key = {guest.guest_id} fetching = {this.props.gettingPropertyCleaners} />
+										)
+									})
+								) : (
+									<Typography variant = 'overline'>
+										You have no upcoming guests.
+									</Typography>
+			
+								)}
+								</>
+							) : (
+								null
+								)}
 
+							{/** Current Guests **/}
 							{this.state.tab === 1 ? (
 								<>
-								{currentGuests.map(guest => {
-									return (
-										<GuestPreview guest = {guest} tab = {this.state.tab} key = {guest.guest_id} fetching = {this.props.gettingPropertyCleaners} />
-									)
-								})}
+								{currentGuests.length > 0 ? (
+									currentGuests.map(guest => {
+										return (
+											<GuestPreview guest = {guest} tab = {this.state.tab} key = {guest.guest_id} fetching = {this.props.gettingPropertyCleaners} />
+										)
+									})
+								) : (
+									<Typography variant = 'overline'>
+										You have no current guests.
+									</Typography>
+			
+								)}
 								</>
-							) : (null)}
+							) : (
+								null
+								)}
 
+							{/** Previous Guests **/}
 							{this.state.tab === 2 ? (
 								<>
-								{previousGuests.map(guest => {
-									return (
-										<GuestPreview guest = {guest} tab = {this.state.tab} key = {guest.guest_id} fetching = {this.props.gettingPropertyCleaners} />
-									)
-								})}
+								{previousGuests.length > 0 ? (
+									previousGuests.map(guest => {
+										return (
+											<GuestPreview guest = {guest} tab = {this.state.tab} key = {guest.guest_id} fetching = {this.props.gettingPropertyCleaners} />
+										)
+									})
+								) : (
+									<Typography variant = 'overline'>
+										You have no previous guests.
+									</Typography>
+								)}
 								</>
-							) : (null)}
-						{/* 
-                        {this.state.tab === 0 && <TabContainer>Upcoming</TabContainer>}
-
-                        {this.state.tab === 1 && <TabContainer>Incomplete</TabContainer>}
-
-                        {this.state.tab === 2 && <TabContainer>Complete</TabContainer>} */}
+							) : (
+								null
+								)}
 					</div>
 				) : null}
 			</div>

--- a/src/components/Guests.js
+++ b/src/components/Guests.js
@@ -28,6 +28,9 @@ import AppBar from '@material-ui/core/AppBar';
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 
+// DateTime handling with moment.js
+import moment from 'moment';
+
 const styles = {
 	card: {
 		minWidth: 275,
@@ -44,6 +47,7 @@ const TopBar = styled.div`
 	flex-flow: row nowrap;
 	justify-content: space-between;
 	align-items: center;
+	margin-bottom: 20px;
 `;
 
 // const TabContainer = styled.div`
@@ -105,6 +109,16 @@ class Guests extends React.Component {
 
 	render() {
 		const { classes } = this.props;
+		let currentTime = moment().format();
+		let upcomingGuests = [];
+		let currentGuests = [];
+		let previousGuests = [];
+
+		if(this.props.guests){
+			upcomingGuests = this.props.guests.filter(guest => moment(guest.checkin).format() > currentTime);
+			previousGuests = this.props.guests.filter(guest => moment(guest.checkout).format() < currentTime);
+			currentGuests = this.props.guests.filter(guest => ((moment(guest.checkin).format() < currentTime) && (moment(guest.checkout).format() > currentTime)));
+		}
 
 		return (
 			<div>
@@ -140,25 +154,41 @@ class Guests extends React.Component {
 						<AppBar position="static">
 							<Tabs value={this.state.tab} variant="fullWidth">
 								<Tab label="Upcoming" value={0} onClick={this.handleTab(0)} />
-								<Tab label="Incomplete" value={1} onClick={this.handleTab(1)} />
-								<Tab label="Complete" value={2} onClick={this.handleTab(2)} />
+								<Tab label="Current" value={1} onClick={this.handleTab(1)} />
+								<Tab label="Previous" value={2} onClick={this.handleTab(2)} />
 							</Tabs>
 						</AppBar>
+						<br></br>
+			
+						{this.state.tab === 0 ? (
+							<>
+							{upcomingGuests.map(guest => {
+								return (
+									<GuestPreview guest = {guest} tab = {this.state.tab} key = {guest.guest_id} fetching = {this.props.gettingPropertyCleaners} />
+								)
+							})}
+							</>
+						) : (null)}
 
-						{this.props.guests ? (
-							<div>
-								{this.props.guests.map(guest => {
+							{this.state.tab === 1 ? (
+								<>
+								{currentGuests.map(guest => {
 									return (
-										<GuestPreview
-											guest={guest}
-											tab={this.state.tab}
-											key={guest.guest_id}
-											fetching={this.props.gettingPropertyCleaners}
-										/>
-									);
+										<GuestPreview guest = {guest} tab = {this.state.tab} key = {guest.guest_id} fetching = {this.props.gettingPropertyCleaners} />
+									)
 								})}
-							</div>
-						) : null}
+								</>
+							) : (null)}
+
+							{this.state.tab === 2 ? (
+								<>
+								{previousGuests.map(guest => {
+									return (
+										<GuestPreview guest = {guest} tab = {this.state.tab} key = {guest.guest_id} fetching = {this.props.gettingPropertyCleaners} />
+									)
+								})}
+								</>
+							) : (null)}
 						{/* 
                         {this.state.tab === 0 && <TabContainer>Upcoming</TabContainer>}
 

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -175,8 +175,6 @@ class Partners extends React.Component {
 				</TopBar>
 
 
-
-
 				{this.props.partners ? (
 					this.props.partners.map(partner => {
 						return <PartnerCard partner={partner} key={partner.user_id} />;
@@ -244,9 +242,6 @@ class Partners extends React.Component {
 					) : (<>
 						<Typography variant = 'overline'>No Invitations Have Been Sent</Typography>
 						</>)}
-
-					
-
 
 			</div>
 		);


### PR DESCRIPTION
Tabs on the guest page are now functional and will filter guest preview renders based on `upcoming` `current` and `previous`. This will also handle empty arrays in the case of no guests, and display a message that there are no guests under that filtration metric.

Also, changes the title of the site to `WellBroomed`.