### PR TITLE
partner views - availability handling, partner properties, etc.

### DIFF
--- a/src/actions/partnerActions.js
+++ b/src/actions/partnerActions.js
@@ -6,6 +6,15 @@ export const INVITE_SENT = 'INVITE_SENT';
 export const FETCHING_INVITES = 'FETCHING_INVITES';
 export const INVITES_FETCHED = 'INVITES_FETCHED';
 
+export const ADDING_AVAILABILITY = 'ADDING_AVAILABILITY';
+export const AVAILABILITY_ADDED = 'AVAILABILITY_ADDED';
+
+export const REMOVING_AVAILABILITY = 'REMOVING_AVAILABILITY';
+export const AVAILABILITY_REMOVED = 'AVAILABILITY_REMOVED';
+
+export const FETCHING_AVAILABLE_PROPERTIES = 'FETCHING_AVAILABLE_PROPERTIES';
+export const AVAILABLE_PROPERTIES_FETCHED = 'AVAILABLE_PROPERTIES_FETCHED';
+
 export const ERROR = 'ERROR';
 
 const backendUrl = process.env.REACT_APP_BACKEND_URL || `http://localhost:5000`;
@@ -60,6 +69,68 @@ export const getAllInvites = () => {
                 dispatch({type: INVITES_FETCHED, payload: res.data.invites});
             }
             
+        }).catch(err => {
+            console.log(err);
+            dispatch({type: ERROR})
+        })
+    }
+}
+
+export const addAvailability = (cleaner_id, property_id) => {
+    let options = setHeaders();
+
+    let body = {
+        cleaner_id: cleaner_id,
+        property_id: property_id,
+    }
+
+    const endpoint = axios.post(`${backendUrl}/api/avail/available_properties`, body, options);
+
+    return dispatch => {
+        dispatch({type: ADDING_AVAILABILITY});
+        
+        endpoint.then(res => {
+            console.log('add avail res', res.data);
+
+            dispatch({type: AVAILABILITY_ADDED});
+        }).catch(err => {
+            console.log(err);
+            dispatch({type: ERROR})
+        })
+    }
+}
+
+export const deleteAvailability = (cleaner_id, property_id) => {
+    let options = setHeaders();
+
+    const endpoint = axios.delete(`${backendUrl}/api/avail/available_properties/${property_id}`, options);
+
+    return dispatch => {
+        dispatch({type: REMOVING_AVAILABILITY});
+        
+        endpoint.then(res => {
+            console.log('remove avail res', res.data);
+
+            dispatch({type: AVAILABILITY_REMOVED});
+        }).catch(err => {
+            console.log(err);
+            dispatch({type: ERROR})
+        })
+    }
+}
+
+export const getAvailableProperties = () => {
+    let options = setHeaders();
+
+    const endpoint = axios.get(`${backendUrl}/api/avail/available_properties`, options);
+
+    return dispatch => {
+        dispatch({type: FETCHING_AVAILABLE_PROPERTIES});
+
+        endpoint.then(res => {
+            console.log('avail props', res.data);
+
+            dispatch({type: AVAILABLE_PROPERTIES_FETCHED, payload: res.data.available_properties})
         }).catch(err => {
             console.log(err);
             dispatch({type: ERROR})

--- a/src/components/PartnerCard.js
+++ b/src/components/PartnerCard.js
@@ -29,8 +29,7 @@ import { withStyles } from '@material-ui/core';
 
 const styles = {
 	card: {
-		maxWidth: 600,
-		margin: '20px auto',
+		
 	},
 	img: {
 		width: 40,
@@ -180,14 +179,14 @@ class PartnerCard extends React.Component {
 								/>
 							</Avatar>
 						}
-						action={
-							<Button
-								variant={this.state.open ? 'contained' : 'outlined'}
-								onClick={this.handlePartnerHouse}
-							>
-								House Availability
-							</Button>
-						}
+						// action={
+						// 	<Button
+						// 		variant={this.state.open ? 'contained' : 'outlined'}
+						// 		onClick={this.handlePartnerHouse}
+						// 	>
+						// 		House Availability
+						// 	</Button>
+						// }
 					/>
 					<CardContent className={classes.content}>
 						<Typography component="p" className={classes.contentTypography}>

--- a/src/components/Partners.js
+++ b/src/components/Partners.js
@@ -181,6 +181,7 @@ class Partners extends React.Component {
 						<AddIcon />
 					</Fab>
 				</TopBar>
+				<br></br>
 
 				{this.props.partners ? (
 					this.props.partners.map(partner => {

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -100,9 +100,18 @@ class Properties extends React.Component {
 		const role = (this.props.user && this.props.user.role) || null;
 		const { user, properties } = this.props;
 
+		// Collect assigned Assistant Properties if user is an assistant
+		let asstProperties = [];
+		if(role !== 'manager' && this.props.properties){
+			if(this.props.user){
+				asstProperties = this.props.properties.filter(property => property.cleaner_id === this.props.user.user_id);
+			}
+		}
+
 		if (role === 'manager')
 			return (
 				<div>
+					{/** Manager View */}
 					<TopBar>
 						<Typography variant="h2">Properties</Typography>{' '}
 						<Fab
@@ -126,7 +135,7 @@ class Properties extends React.Component {
 						</DialogContent>
 					</Dialog>
 
-					{this.props.properties && user.user_id ? (
+					{this.props.properties ? (
 						properties.map(property => {
 							return (
 								<PropertyPreview
@@ -145,33 +154,44 @@ class Properties extends React.Component {
 		else
 			return (
 				<div>
+					{/** Assistant View */}
 					<TopBar>
 						<Typography variant="h2">Properties</Typography>{' '}
 					</TopBar>
-					<Typography variant="h5"> Your Default Properties </Typography>
-					{properties && user.user_id ? (
-						properties
-							.filter(({ cleaner_id }) => cleaner_id === user.user_id)
-							.map(property => {
-								return (
-									<PropertyPreview
-										property={property}
-										key={property.property_id}
-									/>
-								);
-							})
-					) : (
-						<Typography variant="overline">
-							You have not been assigned as the default partner for any
-							properties.
-						</Typography>
-					)}
+					<Typography variant="h5"> Your Assigned Properties</Typography>
 
-					<Typography variant="h5">Properties You're Available For </Typography>
-					{properties && user.user_id ? (
-						properties
-							.filter(({ available }) => available)
+					{/** Assigned Properties */}
+					{this.props.properties ? (
+
+						<>
+						{asstProperties.length > 0 ? (
+							<>
+							{asstProperties
+								.map(property => {
+									return (
+										<PropertyPreview property = {property} key = {property.property_id} />
+									)
+								})}
+							</>
+
+						) : (
+							
+							<Typography variant="overline">
+							You have not been assigned as the default partner for any
+							properties.
+							</Typography>
+						)}
+						</>
+					) : null }
+
+					<Typography variant="h5"> Available Properties </Typography>
+
+					{/** Available Properties */}
+					{/** These are all properties from all managers */}
+					{this.props.properties ? (
+						this.props.properties
 							.map(property => {
+								console.log('MAP PROP', property)
 								return (
 									<PropertyPreview
 										property={property}
@@ -181,8 +201,7 @@ class Properties extends React.Component {
 							})
 					) : (
 						<Typography variant="overline">
-							You have not been assigned as the default partner for any
-							properties.
+							There are no properties available to you.
 						</Typography>
 					)}
 				</div>

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -175,7 +175,7 @@ class Properties extends React.Component {
 							{asstProperties
 								.map(property => {
 									return (
-										<PropertyPreview property = {property} key = {property.property_id} />
+										<PropertyPreview property = {property} key = {property.property_id} assigned = {true}/>
 									)
 								})}
 							</>

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -30,7 +30,7 @@ import Fab from '@material-ui/core/Fab';
 import AddIcon from '@material-ui/icons/Add';
 
 // Actions
-import { getUserProperties } from '../actions';
+import { getUserProperties, getAvailableProperties } from '../actions/index';
 import PropertyPreview from './PropertyPreview';
 
 const TopBar = styled.div`
@@ -71,6 +71,12 @@ class Properties extends React.Component {
 		// refreshProperties will be set to true once the user is checked
 		if (prevProps.refreshProperties !== this.props.refreshProperties) {
 			this.props.getUserProperties();
+		}
+
+		if(prevProps.user !== this.props.user){
+			if(this.props.user.role !== 'manager'){
+				this.props.getAvailableProperties();
+			}
 		}
 	}
 
@@ -215,6 +221,8 @@ const mapStateToProps = state => {
 		properties: state.propertyReducer.properties,
 		refreshProperties: state.propertyReducer.refreshProperties,
 		userChecked: state.authReducer.userChecked,
+		availableProperties: state.partnerReducer.availableProperties,
+		refreshAvailable: state.partnerReducer.refreshAvailable,
 	};
 };
 export default withRouter(
@@ -223,6 +231,7 @@ export default withRouter(
 		{
 			// actions
 			getUserProperties,
+			getAvailableProperties,
 		}
 	)(withStyles(styles)(Properties))
 );

--- a/src/components/Properties.js
+++ b/src/components/Properties.js
@@ -164,7 +164,7 @@ class Properties extends React.Component {
 					<TopBar>
 						<Typography variant="h2">Properties</Typography>{' '}
 					</TopBar>
-					<Typography variant="h5"> Your Assigned Properties</Typography>
+					<Typography variant="h5"> Assigned Properties</Typography>
 
 					{/** Assigned Properties */}
 					{this.props.properties ? (
@@ -190,8 +190,9 @@ class Properties extends React.Component {
 						</>
 					) : null }
 
-					<Typography variant="h5"> Available Properties </Typography>
-
+					<Typography variant="h5"> Potential Properties </Typography>
+					<Typography variant = 'subtitle'>Mark yourself available to be assigned for shifts.</Typography>
+					<br></br>
 					{/** Available Properties */}
 					{/** These are all properties from all managers */}
 					{this.props.properties ? (

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -87,11 +87,24 @@ const styles = {
 
 class PropertyPreview extends React.Component {
 	// check this property's availability status against the availabilities in state
+
+
 	componentDidMount(){
 
 		this.setState({
 			cleaner_id: this.props.property.cleaner_id || '',
 		});
+
+		if(this.props.availableProperties){
+			let currentProperty = this.props.property.property_id;
+
+			let searchResult = this.props.availableProperties.find(property => property.property_id === currentProperty);
+			if(searchResult || searchResult !== undefined){
+				this.setState({
+					available: true,
+				})
+			}
+		}
 	}
 
 	componentDidUpdate(prevProps){
@@ -280,7 +293,7 @@ class PropertyPreview extends React.Component {
 							</Link>
 
 							<CardActions>
-								<FormControlLabel control = {<Switch checked = {this.state.available} onChange = {this.handleSwitch('available')} value = 'available' />} label = 'Available' />
+								<FormControlLabel control = {<Switch checked = {this.state.available} onChange = {this.handleSwitch('available')} value = 'available' />} label = {this.state.available ? 'Available' : 'Unavailable'} />
 							</CardActions>
 					</CardContainer>
 				</Card>

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -201,6 +201,7 @@ class PropertyPreview extends React.Component {
 		if (role === 'manager') {
 			return (
 				<div>
+					
 					{/** Delete Modal **/}
 					<Dialog open={this.state.deleteModal} onClose={this.toggleDelete}>
 						<DialogContent>
@@ -283,6 +284,8 @@ class PropertyPreview extends React.Component {
 			);
 		} else {
 			return (
+				<>
+				<br></br>
 				<Card>
 					<CardContainer>
 							<Link to={`/properties/${property.property_id}`}>
@@ -297,6 +300,7 @@ class PropertyPreview extends React.Component {
 							</CardActions>
 					</CardContainer>
 				</Card>
+				</>
 			);
 		}
 	}

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -234,15 +234,15 @@ class PropertyPreview extends React.Component {
 			);
 		} else {
 			return (
-				<Card className={classes.card} key={property.id}>
-					<Link to={`/properties/${property.property_id}`}>
-						<CardHeader
-							title={property.property_name}
-							subheader={property.address}
-						/>
-					</Link>
-
-					<CardContent />
+				<Card>
+					<CardContainer>
+							<Link to={`/properties/${property.property_id}`}>
+								<CardText>
+									<Typography variant="h4">{property.property_name}</Typography>
+									<Typography variant="h5">{property.address}</Typography>
+								</CardText>
+							</Link>
+					</CardContainer>
 				</Card>
 			);
 		}

--- a/src/components/PropertyPreview.js
+++ b/src/components/PropertyPreview.js
@@ -296,7 +296,9 @@ class PropertyPreview extends React.Component {
 							</Link>
 
 							<CardActions>
+								{!this.props.assigned ? (
 								<FormControlLabel control = {<Switch checked = {this.state.available} onChange = {this.handleSwitch('available')} value = 'available' />} label = {this.state.available ? 'Available' : 'Unavailable'} />
+								) : (null)}
 							</CardActions>
 					</CardContainer>
 				</Card>

--- a/src/reducers/partnerReducer.js
+++ b/src/reducers/partnerReducer.js
@@ -1,12 +1,19 @@
 import {
     INVITES_FETCHED,
     INVITE_SENT,
+    AVAILABILITY_ADDED,
+    AVAILABILITY_REMOVED,
+    
+    AVAILABLE_PROPERTIES_FETCHED,
+
     ERROR,
 } from '../actions';
 
 const initialState = {
     refreshInvites: false,
-	invites: null,
+    refreshAvailable: false,
+    invites: null,
+    availableProperties: null,
 };
 
 const partnerReducer = (state = initialState, action) => {
@@ -22,6 +29,25 @@ const partnerReducer = (state = initialState, action) => {
                 ...state,
                 invites: action.payload,
                 refreshInvites: false,
+            }
+        
+        case AVAILABILITY_ADDED:
+            return {
+                ...state,
+                refreshAvailable: true,
+            }
+
+        case AVAILABILITY_REMOVED:
+            return {
+                ...state,
+                refreshAvailable: true,
+            }
+
+        case AVAILABLE_PROPERTIES_FETCHED:
+            return {
+                ...state,
+                availableProperties: action.payload,
+                refreshAvailable: false,
             }
 		
 		default:


### PR DESCRIPTION
Makes the availability handling more intuitive for partners.

Now, on the properties page, partner property cards will have a switch that can toggle availability status. Assigned properties will not appear until a manager assigns an available partner to that property. The toggle is hidden for assigned properties.

This switch will add or remove availability entries in the available cleaners table.

**TODO**
These updates are for partner views only currently, expect revisions to the manager's partners interface to come later (specifically a cleaner overview of partners and their assigned/available properties).

We'll also need to add a handler for partners that revoke availability from properties they are assigned to. As of right now, this requires a manual removal of the cleaner from the property by the manager.

This also fixes an issue with a page refresh crashing the application on the partners page.